### PR TITLE
118-ci/pre-commit → develop: Added linter and formatting pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    node_modules,
+    build,
+    dist,
+    */migrations/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,50 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        files: ^scalea/.*\.py$
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: ^scalea/.*\.py$
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        files: ^scalea/.*\.py$
+        additional_dependencies: [flake8-bugbear==24.8.19]
+
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint (backend)
+        entry: bash -lc 'cd backend && pylint core'
+        language: system
+        pass_filenames: false
+        files: ^scalea/.*\.py$
+
+      - id: eslint-frontend
+        name: eslint (frontend)
+        entry: bash -lc 'cd frontend && npm run lint'
+        language: system
+        pass_filenames: false
+        files: ^frontend/.*\.(js|jsx|ts|tsx)$
+
+  # Optional commit-msg lint (conventional commits)
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -261,20 +261,50 @@ pip install -r startup_gateway/requirements-dev.txt
 
 #### Step 2: Running the linter
 
+Python tools:
+- `black` (format)
+- `isort` (import order)
+- `flake8` (style/lint)
+- `pylint` (deeper static analysis)
+
+Frontend tool:
+- `eslint` (TS/React linting)
+
 **Action**: To lint and format your staged files, run the following command from the project root:
+**Step 1**: Install necessary dependencies for both backend and frontend:
+```bash
+pip install -r scalea/requirements-dev.txt
+cd frontend
+npm install
+cd ..
+```
 
-**Command:**
+**Step 2**: Enable git commit hooks
 
+```bash
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+
+**Action**: To lint and format your staged files, run the following command from the project root:
 ```
 pre-commit run
 ```
 
 Alternatively, if you want to lint and format all files, run:
-
-**Command:**
-
 ```
 pre-commit run --all-files
+```
+
+#### Run individual tools
+
+```bash
+black scalea
+isort scalea
+flake8 scalea
+cd scalea && pylint core
+cd frontend && npm run lint
 ```
 
 #### GitHub Actions

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint", "react-hooks", "react-refresh"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  rules: {
+    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+  },
+  ignorePatterns: ["dist", "node_modules"],
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.black]
+line-length = 120
+target-version = ["py310"]
+extend-exclude = '''
+/(
+  \.git
+  | \.venv
+  | venv
+  | node_modules
+  | dist
+  | build
+  | migrations
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 120
+src_paths = ["backend"]
+skip_glob = ["**/migrations/*.py"]
+
+[tool.pylint.main]
+ignore = ["migrations", "venv", ".venv", "node_modules"]
+load-plugins = ["pylint_django"]
+django-settings-module = "core.settings"
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.messages_control]
+disable = [
+  "missing-module-docstring",
+  "missing-class-docstring",
+  "missing-function-docstring"
+]

--- a/scalea/requirements-dev.txt
+++ b/scalea/requirements-dev.txt
@@ -1,0 +1,6 @@
+isort==5.13.2
+flake8==7.1.1
+flake8-bugbear==24.8.19
+pylint==3.3.1
+pylint-django==2.5.5
+pre-commit==3.8.0


### PR DESCRIPTION
CI: Added linter and formatting pre-commit hooks

Python tools:
- `black` (format)
- `isort` (import order)
- `flake8` (style/lint)
- `pylint` (deeper static analysis)

Frontend tool:
- `eslint` (TS/React linting)