### PR TITLE
BE - 75: POST /api/auth/register/ — registration endpoint (startup & investor)

### DIFF
--- a/scalea/dashboard/admin.py
+++ b/scalea/dashboard/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/scalea/dashboard/models.py
+++ b/scalea/dashboard/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/scalea/dashboard/tests.py
+++ b/scalea/dashboard/tests.py
@@ -3,12 +3,12 @@ from django.test import TestCase
 
 class LandingContentTest(TestCase):
     def test_landing_endpoint(self):
-        response = self.client.get("/api/content/landing/")
+        response = self.client.get('/api/content/landing/')
         data = response.json()
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn("hero", data)
-        self.assertIn("for_whom", data)
-        self.assertIn("why_worth", data)
-        self.assertIn("footer_links", data)
+        self.assertIn('hero', data)
+        self.assertIn('for_whom', data)
+        self.assertIn('why_worth', data)
+        self.assertIn('footer_links', data)

--- a/scalea/dashboard/views.py
+++ b/scalea/dashboard/views.py
@@ -2,56 +2,44 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 LANDING_CONTENT = {
-    "hero": {
-        "title": "Connect startups with investors",
-        "subtitle": "Turn ideas into real businesses",
-        "cta_text": "Join now",
-        "hero_images": [
-            "/static/images/hero1.png",
-            "/static/images/hero2.png"
-        ]
+    'hero': {
+        'title': 'Connect startups with investors',
+        'subtitle': 'Turn ideas into real businesses',
+        'cta_text': 'Join now',
+        'hero_images': ['/static/images/hero1.png', '/static/images/hero2.png'],
     },
-    "for_whom": [
+    'for_whom': [
         {
-            "icon": "startup",
-            "title": "For Startups",
-            "desc": "Showcase your ideas and find investors"
+            'icon': 'startup',
+            'title': 'For Startups',
+            'desc': 'Showcase your ideas and find investors',
         },
         {
-            "icon": "investor",
-            "title": "For Investors",
-            "desc": "Discover promising startups to invest in"
+            'icon': 'investor',
+            'title': 'For Investors',
+            'desc': 'Discover promising startups to invest in',
         },
         {
-            "icon": "partner",
-            "title": "For Partners",
-            "desc": "Collaborate and grow together"
-        }
+            'icon': 'partner',
+            'title': 'For Partners',
+            'desc': 'Collaborate and grow together',
+        },
     ],
-    "why_worth": [
-        {
-            "title": "Fast Matching",
-            "desc": "Connect startups and investors quickly"
-        },
-        {
-            "title": "Secure Platform",
-            "desc": "Safe communication and data protection"
-        },
-        {
-            "title": "Scalable Network",
-            "desc": "Grow your business opportunities"
-        }
+    'why_worth': [
+        {'title': 'Fast Matching', 'desc': 'Connect startups and investors quickly'},
+        {'title': 'Secure Platform', 'desc': 'Safe communication and data protection'},
+        {'title': 'Scalable Network', 'desc': 'Grow your business opportunities'},
     ],
-    "footer_links": {
-        "left": [
-            {"text": "About", "url": "/about"},
-            {"text": "How it works", "url": "/how-it-works"}
+    'footer_links': {
+        'left': [
+            {'text': 'About', 'url': '/about'},
+            {'text': 'How it works', 'url': '/how-it-works'},
         ],
-        "right": [
-            {"text": "Contact", "url": "/contact"},
-            {"text": "GitHub", "url": "https://github.com"}
-        ]
-    }
+        'right': [
+            {'text': 'Contact', 'url': '/contact'},
+            {'text': 'GitHub', 'url': 'https://github.com'},
+        ],
+    },
 }
 
 

--- a/scalea/investors/admin.py
+++ b/scalea/investors/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import InvestorProfile
 
 admin.site.register(InvestorProfile)

--- a/scalea/investors/admin.py
+++ b/scalea/investors/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import InvestorProfile
 
-# Register your models here.
+admin.site.register(InvestorProfile)

--- a/scalea/investors/models.py
+++ b/scalea/investors/models.py
@@ -17,7 +17,7 @@ class InvestorProfile(models.Model):
 
 class Investment(models.Model):
     investor_profile = models.ForeignKey(InvestorProfile, on_delete=models.CASCADE)
-    project = models.ForeignKey("projects.Project", on_delete=models.CASCADE)
+    project = models.ForeignKey('projects.Project', on_delete=models.CASCADE)
     amount = models.DecimalField(max_digits=10, decimal_places=0, default=0)
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -25,14 +25,14 @@ class Investment(models.Model):
 class SavedStartup(models.Model):
     investor_profile = models.ForeignKey(InvestorProfile, on_delete=models.CASCADE)
     startup_profile = models.ForeignKey(
-        "startups.StartupProfile", on_delete=models.CASCADE
+        'startups.StartupProfile', on_delete=models.CASCADE
     )
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["investor_profile", "startup_profile"],
-                name="unique_saved_startup",
+                fields=['investor_profile', 'startup_profile'],
+                name='unique_saved_startup',
             )
         ]

--- a/scalea/investors/tests.py
+++ b/scalea/investors/tests.py
@@ -1,16 +1,16 @@
 from django.test import TestCase
-
-from investors.models import InvestorProfile, SavedStartup
 from startups.models import StartupProfile
 from users.models import User
+
+from investors.models import InvestorProfile, SavedStartup
 
 
 class InvestorProfileModelTests(TestCase):
     def test_investor_profile_creation(self):
         user = User.objects.create_user(
-            username="investoruser",
-            email="investor@example.com",
-            password="123qwe!@#",
+            username='investoruser',
+            email='investor@example.com',
+            password='123qwe!@#',
             is_startup=False,
             is_investor=True,
             is_verified=True,
@@ -18,34 +18,34 @@ class InvestorProfileModelTests(TestCase):
 
         investor_profile = InvestorProfile.objects.create(
             user=user,
-            company_name="Investor Company",
-            bio="Angel investor",
-            investment_focus="AI, SaaS",
-            website="https://www.investorcompany.com",
+            company_name='Investor Company',
+            bio='Angel investor',
+            investment_focus='AI, SaaS',
+            website='https://www.investorcompany.com',
         )
 
         self.assertEqual(investor_profile.user, user)
-        self.assertEqual(investor_profile.company_name, "Investor Company")
-        self.assertEqual(investor_profile.bio, "Angel investor")
-        self.assertEqual(investor_profile.investment_focus, "AI, SaaS")
-        self.assertEqual(investor_profile.website, "https://www.investorcompany.com")
+        self.assertEqual(investor_profile.company_name, 'Investor Company')
+        self.assertEqual(investor_profile.bio, 'Angel investor')
+        self.assertEqual(investor_profile.investment_focus, 'AI, SaaS')
+        self.assertEqual(investor_profile.website, 'https://www.investorcompany.com')
 
 
 class SavedStartupModelTests(TestCase):
     def test_saved_startup_creation(self):
         investor_user = User.objects.create_user(
-            username="investoruser",
-            email="investor@example.com",
-            password="123qwe!@#",
+            username='investoruser',
+            email='investor@example.com',
+            password='123qwe!@#',
             is_startup=False,
             is_investor=True,
             is_verified=True,
         )
 
         startup_user = User.objects.create_user(
-            username="startupuser",
-            email="startup@example.com",
-            password="123qwe!@#",
+            username='startupuser',
+            email='startup@example.com',
+            password='123qwe!@#',
             is_startup=True,
             is_investor=False,
             is_verified=True,
@@ -53,17 +53,17 @@ class SavedStartupModelTests(TestCase):
 
         investor_profile = InvestorProfile.objects.create(
             user=investor_user,
-            company_name="Investor Company",
-            bio="Angel investor",
-            investment_focus="AI, SaaS",
-            website="https://www.investorcompany.com",
+            company_name='Investor Company',
+            bio='Angel investor',
+            investment_focus='AI, SaaS',
+            website='https://www.investorcompany.com',
         )
 
         startup_profile = StartupProfile.objects.create(
             user=startup_user,
-            company_name="Test Company",
-            description="This is a test company.",
-            website="https://www.testcompany.com",
+            company_name='Test Company',
+            description='This is a test company.',
+            website='https://www.testcompany.com',
         )
 
         saved_startup = SavedStartup.objects.create(

--- a/scalea/investors/views.py
+++ b/scalea/investors/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/scalea/manage.py
+++ b/scalea/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
@@ -12,8 +13,8 @@ def main():
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
+            'available on your PYTHONPATH environment variable? Did you '
+            'forget to activate a virtual environment?'
         ) from exc
     execute_from_command_line(sys.argv)
 

--- a/scalea/messages/admin.py
+++ b/scalea/messages/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/scalea/messages/apps.py
+++ b/scalea/messages/apps.py
@@ -2,6 +2,6 @@ from django.apps import AppConfig
 
 
 class MessagesConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "messages"
-    label = "user_messages"
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'messages'
+    label = 'user_messages'

--- a/scalea/messages/models.py
+++ b/scalea/messages/models.py
@@ -8,18 +8,18 @@ class Message(models.Model):
     class Role(models.TextChoices):
         """Available user roles for sending and receiving messages."""
 
-        STARTUP = "startup", "Startup"
-        INVESTOR = "investor", "Investor"
+        STARTUP = 'startup', 'Startup'
+        INVESTOR = 'investor', 'Investor'
 
     sender = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name="sent_messages",
+        related_name='sent_messages',
     )
     receiver = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name="received_messages",
+        related_name='received_messages',
     )
     sender_role = models.CharField(max_length=20, choices=Role.choices)
     receiver_role = models.CharField(max_length=20, choices=Role.choices)
@@ -29,7 +29,7 @@ class Message(models.Model):
 
     def __str__(self):
         """Return a readable representation of the message sender and receiver."""
-        return f"{self.sender} -> {self.receiver}"
+        return f'{self.sender} -> {self.receiver}'
 
 
 class Notification(models.Model):
@@ -38,13 +38,13 @@ class Notification(models.Model):
     class Role(models.TextChoices):
         """Available user roles for displaying notifications."""
 
-        STARTUP = "startup", "Startup"
-        INVESTOR = "investor", "Investor"
+        STARTUP = 'startup', 'Startup'
+        INVESTOR = 'investor', 'Investor'
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name="notifications",
+        related_name='notifications',
     )
     role = models.CharField(max_length=20, choices=Role.choices)
     message = models.TextField()
@@ -53,4 +53,4 @@ class Notification(models.Model):
 
     def __str__(self):
         """Return a readable representation of the notification recipient."""
-        return f"Notification for {self.user}"
+        return f'Notification for {self.user}'

--- a/scalea/messages/tests.py
+++ b/scalea/messages/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/scalea/messages/views.py
+++ b/scalea/messages/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/scalea/projects/admin.py
+++ b/scalea/projects/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/scalea/projects/models.py
+++ b/scalea/projects/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 
 class Project(models.Model):
-    startup = models.ForeignKey("startups.StartupProfile", on_delete=models.CASCADE)
+    startup = models.ForeignKey('startups.StartupProfile', on_delete=models.CASCADE)
     status = models.BooleanField()
     title = models.CharField(max_length=255)
     short_description = models.CharField(max_length=500, blank=True)

--- a/scalea/projects/tests.py
+++ b/scalea/projects/tests.py
@@ -1,16 +1,16 @@
 from django.test import TestCase
-
-from projects.models import Project
 from startups.models import StartupProfile
 from users.models import User
+
+from projects.models import Project
 
 
 class ProjectModelTests(TestCase):
     def test_project_creation(self):
         user = User.objects.create_user(
-            username="startupuser",
-            email="startup@example.com",
-            password="123qwe!@#",
+            username='startupuser',
+            email='startup@example.com',
+            password='123qwe!@#',
             is_startup=True,
             is_investor=False,
             is_verified=True,
@@ -18,22 +18,22 @@ class ProjectModelTests(TestCase):
 
         startup_profile = StartupProfile.objects.create(
             user=user,
-            company_name="Startup Company",
-            description="Startup description",
-            website="https://www.startupcompany.com",
+            company_name='Startup Company',
+            description='Startup description',
+            website='https://www.startupcompany.com',
         )
 
         project = Project.objects.create(
             startup=startup_profile,
             status=True,
-            title="AI Matching Platform",
-            short_description="Platform connecting startups with investors.",
-            description="Detailed project description.",
+            title='AI Matching Platform',
+            short_description='Platform connecting startups with investors.',
+            description='Detailed project description.',
             funding_goal=500000,
             current_funding=100000,
         )
 
         self.assertEqual(project.startup, startup_profile)
-        self.assertEqual(project.title, "AI Matching Platform")
+        self.assertEqual(project.title, 'AI Matching Platform')
         self.assertTrue(project.status)
         self.assertEqual(project.current_funding, 100000)

--- a/scalea/projects/views.py
+++ b/scalea/projects/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/scalea/scalea/settings.py
+++ b/scalea/scalea/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+
 from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -21,91 +22,91 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config("SECRET_KEY")
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("DEBUG", default=False, cast=bool)
+DEBUG = config('DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = config(
-    "ALLOWED_HOSTS",
-    default="127.0.0.1,localhost",
-    cast=lambda v: [h.strip() for h in v.split(",")],
+    'ALLOWED_HOSTS',
+    default='127.0.0.1,localhost',
+    cast=lambda v: [h.strip() for h in v.split(',')],
 )
 
 # Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "corsheaders",
-    "rest_framework",
-    "users",
-    "startups",
-    "investors",
-    "projects",
-    "messages.apps.MessagesConfig",
-    "dashboard",
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'corsheaders',
+    'rest_framework',
+    'users',
+    'startups',
+    'investors',
+    'projects',
+    'messages.apps.MessagesConfig',
+    'dashboard',
 ]
 
-AUTH_USER_MODEL = "users.User"
+AUTH_USER_MODEL = 'users.User'
 
 MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = "scalea.urls"
+ROOT_URLCONF = 'scalea.urls'
 
 TEMPLATES = [
     {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.template.context_processors.debug",
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = "scalea.wsgi.application"
+WSGI_APPLICATION = 'scalea.wsgi.application'
 
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-USE_POSTGRES = config("USE_POSTGRES", default=False, cast=bool)
+USE_POSTGRES = config('USE_POSTGRES', default=False, cast=bool)
 
 if USE_POSTGRES:
     DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": config("POSTGRES_DB", default="scalea_db"),
-            "USER": config("POSTGRES_USER", default="scalea_user"),
-            "PASSWORD": config("POSTGRES_PASSWORD", default="scalea_password"),
-            "HOST": config("POSTGRES_HOST", default="localhost"),
-            "PORT": config("POSTGRES_PORT", default="5432"),
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': config('POSTGRES_DB', default='scalea_db'),
+            'USER': config('POSTGRES_USER', default='scalea_user'),
+            'PASSWORD': config('POSTGRES_PASSWORD', default='scalea_password'),
+            'HOST': config('POSTGRES_HOST', default='localhost'),
+            'PORT': config('POSTGRES_PORT', default='5432'),
         }
     }
 else:
     DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
         }
     }
 
@@ -115,16 +116,16 @@ else:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
     {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
     {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
     {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
 
@@ -132,9 +133,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = "UTC"
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
@@ -144,21 +145,21 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = 'static/'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-    "http://frontend:5173",
+    'http://localhost:5173',
+    'http://127.0.0.1:5173',
+    'http://frontend:5173',
 ]
 
 REST_FRAMEWORK = {
-    "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.AllowAny',
     ],
 }

--- a/scalea/scalea/urls.py
+++ b/scalea/scalea/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.http import JsonResponse
-from django.urls import path
+from django.urls import path, include
 
 
 def health_check(request):
@@ -27,4 +27,5 @@ def health_check(request):
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/health/", health_check),
+    path('api/auth/', include('users.urls')),
 ]

--- a/scalea/scalea/urls.py
+++ b/scalea/scalea/urls.py
@@ -18,16 +18,16 @@ Including another URLconf
 from dashboard.views import LandingContentAPIView
 from django.contrib import admin
 from django.http import JsonResponse
-from django.urls import path, include
+from django.urls import include, path
 
 
 def health_check(_request):
-    return JsonResponse({"status": "ok"})
+    return JsonResponse({'status': 'ok'})
 
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("api/health/", health_check),
+    path('admin/', admin.site.urls),
+    path('api/health/', health_check),
     path('api/auth/', include('users.urls')),
-    path("api/content/landing/", LandingContentAPIView.as_view()),
+    path('api/content/landing/', LandingContentAPIView.as_view()),
 ]

--- a/scalea/startups/admin.py
+++ b/scalea/startups/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import StartupProfile
 
-# Register your models here.
+admin.site.register(StartupProfile)

--- a/scalea/startups/admin.py
+++ b/scalea/startups/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import StartupProfile
 
 admin.site.register(StartupProfile)

--- a/scalea/startups/tests.py
+++ b/scalea/startups/tests.py
@@ -1,15 +1,15 @@
 from django.test import TestCase
+from users.models import User
 
 from startups.models import StartupProfile
-from users.models import User
 
 
 class StartupProfileModelTests(TestCase):
     def test_startup_profile_creation(self):
         user = User.objects.create_user(
-            username="startupuser",
-            email="startup@example.com",
-            password="123qwe!@#",
+            username='startupuser',
+            email='startup@example.com',
+            password='123qwe!@#',
             is_startup=True,
             is_investor=False,
             is_verified=True,
@@ -17,12 +17,12 @@ class StartupProfileModelTests(TestCase):
 
         startup_profile = StartupProfile.objects.create(
             user=user,
-            company_name="Test Company",
-            description="This is a test company.",
-            website="https://www.testcompany.com",
+            company_name='Test Company',
+            description='This is a test company.',
+            website='https://www.testcompany.com',
         )
 
         self.assertEqual(startup_profile.user, user)
-        self.assertEqual(startup_profile.company_name, "Test Company")
-        self.assertEqual(startup_profile.description, "This is a test company.")
-        self.assertEqual(startup_profile.website, "https://www.testcompany.com")
+        self.assertEqual(startup_profile.company_name, 'Test Company')
+        self.assertEqual(startup_profile.description, 'This is a test company.')
+        self.assertEqual(startup_profile.website, 'https://www.testcompany.com')

--- a/scalea/startups/views.py
+++ b/scalea/startups/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/scalea/users/admin.py
+++ b/scalea/users/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import User
 
 admin.site.register(User)

--- a/scalea/users/admin.py
+++ b/scalea/users/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import User
 
-# Register your models here.
+admin.site.register(User)

--- a/scalea/users/models.py
+++ b/scalea/users/models.py
@@ -10,8 +10,8 @@ class User(AbstractUser):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
-    USERNAME_FIELD = "email"
-    REQUIRED_FIELDS = ["username"]
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = ['username']
 
     def __str__(self):
         return self.email

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -1,18 +1,20 @@
-from django.db import transaction
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.core import exceptions
+from django.db import transaction
+from investors.models import InvestorProfile
 from rest_framework import serializers, status
 from rest_framework.exceptions import APIException
 from startups.models import StartupProfile
-from investors.models import InvestorProfile
 
 User = get_user_model()
+
 
 class DuplicateEmailError(APIException):
     status_code = status.HTTP_409_CONFLICT
     default_detail = 'A user with this email already exists.'
     default_code = 'duplicate_email'
+
 
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField()
@@ -22,7 +24,9 @@ class RegisterSerializer(serializers.Serializer):
     short_pitch = serializers.CharField(required=False, allow_blank=True, default='')
     website = serializers.URLField(required=False, allow_blank=True, default='')
     bio = serializers.CharField(required=False, allow_blank=True, default='')
-    investment_focus = serializers.CharField(required=False, allow_blank=True, default='')
+    investment_focus = serializers.CharField(
+        required=False, allow_blank=True, default=''
+    )
 
     def validate_email(self, value):
         if User.objects.filter(email=value).exists():
@@ -33,7 +37,7 @@ class RegisterSerializer(serializers.Serializer):
         try:
             validate_password(value)
         except exceptions.ValidationError as e:
-            raise serializers.ValidationError(list(e.messages))
+            raise serializers.ValidationError(list(e.messages)) from e
         return value
 
     @transaction.atomic
@@ -48,7 +52,7 @@ class RegisterSerializer(serializers.Serializer):
             password=password,
             is_active=False,
             is_startup=(role == 'startup'),
-            is_investor=(role == 'investor')
+            is_investor=(role == 'investor'),
         )
 
         if role == 'startup':
@@ -56,14 +60,14 @@ class RegisterSerializer(serializers.Serializer):
                 user=user,
                 company_name=validated_data.get('company_name', ''),
                 description=validated_data.get('short_pitch', ''),
-                website=validated_data.get('website', '')
+                website=validated_data.get('website', ''),
             )
         else:
             InvestorProfile.objects.create(
                 user=user,
                 company_name=validated_data.get('company_name', ''),
                 bio=validated_data.get('bio', ''),
-                investment_focus=validated_data.get('investment_focus', '')
+                investment_focus=validated_data.get('investment_focus', ''),
             )
 
         self.send_verification_email(user)

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -72,7 +72,14 @@ class RegisterSerializer(serializers.Serializer):
         return user
 
     def send_verification_email(self, user):
+        # TODO(i-taras): Implement actual SMTP dispatch & activation token logic [#99]
+        # Users will be LOCKED OUT until this method is implemented
+        # and the activation endpoint is ready.
+        # This is a placeholder to allow the registration schema to merge.
         pass
 
     def send_already_registered_email(self, user):
+        # TODO(i-taras): Implement resend logic for verification emails [#99]
+        # This is a placeholder to allow the registration schema to merge and
+        # NO email is actually dispatched.
         pass

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -3,17 +3,10 @@ from django.contrib.auth.password_validation import validate_password
 from django.core import exceptions
 from django.db import transaction
 from investors.models import InvestorProfile
-from rest_framework import serializers, status
-from rest_framework.exceptions import APIException
+from rest_framework import serializers
 from startups.models import StartupProfile
 
 User = get_user_model()
-
-
-class DuplicateEmailError(APIException):
-    status_code = status.HTTP_409_CONFLICT
-    default_detail = 'A user with this email already exists.'
-    default_code = 'duplicate_email'
 
 
 class RegisterSerializer(serializers.Serializer):
@@ -29,9 +22,8 @@ class RegisterSerializer(serializers.Serializer):
     )
 
     def validate_email(self, value):
-        if User.objects.filter(email=value).exists():
-            raise DuplicateEmailError()
-        return value
+        normalized_email = User.objects.normalize_email(value)
+        return normalized_email.lower()
 
     def validate_password(self, value):
         try:
@@ -45,6 +37,12 @@ class RegisterSerializer(serializers.Serializer):
         role = validated_data.pop('role')
         password = validated_data.pop('password')
         email = validated_data.pop('email')
+
+        user = User.objects.filter(email=email).first()
+
+        if user:
+            self.send_already_registered_email(user)
+            return user
 
         user = User.objects.create_user(
             username=email,
@@ -74,4 +72,7 @@ class RegisterSerializer(serializers.Serializer):
         return user
 
     def send_verification_email(self, user):
+        pass
+
+    def send_already_registered_email(self, user):
         pass

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -1,0 +1,73 @@
+from django.db import transaction
+from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core import exceptions
+from rest_framework import serializers, status
+from rest_framework.exceptions import APIException
+from startups.models import StartupProfile
+from investors.models import InvestorProfile
+
+User = get_user_model()
+
+class DuplicateEmailError(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = 'A user with this email already exists.'
+    default_code = 'duplicate_email'
+
+class RegisterSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True, min_length=8)
+    role = serializers.ChoiceField(choices=['startup', 'investor'])
+    company_name = serializers.CharField(required=False, allow_blank=True, default='')
+    short_pitch = serializers.CharField(required=False, allow_blank=True, default='')
+    website = serializers.URLField(required=False, allow_blank=True, default='')
+    bio = serializers.CharField(required=False, allow_blank=True, default='')
+    investment_focus = serializers.CharField(required=False, allow_blank=True, default='')
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise DuplicateEmailError()
+        return value
+
+    def validate_password(self, value):
+        try:
+            validate_password(value)
+        except exceptions.ValidationError as e:
+            raise serializers.ValidationError(list(e.messages))
+        return value
+
+    @transaction.atomic
+    def create(self, validated_data):
+        role = validated_data.pop('role')
+        password = validated_data.pop('password')
+        email = validated_data.pop('email')
+
+        user = User.objects.create_user(
+            username=email,
+            email=email,
+            password=password,
+            is_active=False,
+            is_startup=(role == 'startup'),
+            is_investor=(role == 'investor')
+        )
+
+        if role == 'startup':
+            StartupProfile.objects.create(
+                user=user,
+                company_name=validated_data.get('company_name', ''),
+                description=validated_data.get('short_pitch', ''),
+                website=validated_data.get('website', '')
+            )
+        else:
+            InvestorProfile.objects.create(
+                user=user,
+                company_name=validated_data.get('company_name', ''),
+                bio=validated_data.get('bio', ''),
+                investment_focus=validated_data.get('investment_focus', '')
+            )
+
+        self.send_verification_email(user)
+        return user
+
+    def send_verification_email(self, user):
+        pass

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -1,6 +1,13 @@
 from django.test import TestCase
-
 from users.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.contrib.auth import get_user_model
+from startups.models import StartupProfile
+from investors.models import InvestorProfile
+
+User = get_user_model()
 
 
 class UserModelTests(TestCase):
@@ -19,3 +26,73 @@ class UserModelTests(TestCase):
         self.assertTrue(user.is_startup)
         self.assertFalse(user.is_investor)
         self.assertTrue(user.is_verified)
+
+
+class RegistrationAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('register')
+        self.valid_startup_data = {
+            "email": "startup@example.com",
+            "password": "StrongPassword123!",
+            "role": "startup",
+            "company_name": "Tech Future",
+            "short_pitch": "We build AI solutions."
+        }
+
+    def test_successful_startup_registration(self):
+        response = self.client.post(self.url, self.valid_startup_data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(User.objects.filter(email="startup@example.com").exists())
+        self.assertTrue(StartupProfile.objects.filter(company_name="Tech Future").exists())
+
+        user = User.objects.get(email="startup@example.com")
+        self.assertFalse(user.is_active)
+
+    def test_successful_investor_registration(self):
+        data = {
+            "email": "investor@example.com",
+            "password": "StrongPassword123!",
+            "role": "investor",
+            "bio": "Experienced angel investor.",
+            "investment_focus": "SaaS"
+        }
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(InvestorProfile.objects.filter(user__email="investor@example.com").exists())
+
+    def test_registration_duplicate_email_returns_409(self):
+        User.objects.create_user(
+            username="startup@example.com",
+            email="startup@example.com",
+            password="Password123!"
+        )
+
+        response = self.client.post(self.url, self.valid_startup_data)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data['detail'], 'A user with this email already exists.')
+
+    def test_registration_weak_password_returns_400(self):
+        data = self.valid_startup_data.copy()
+        data['password'] = '123'
+
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('password', response.data)
+
+    def test_registration_invalid_email_returns_400(self):
+        data = self.valid_startup_data.copy()
+        data['email'] = 'not-an-email'
+
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_registration_missing_role_returns_400(self):
+        data = self.valid_startup_data.copy()
+        data.pop('role')
+
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -66,19 +66,22 @@ class RegistrationAPITests(TestCase):
             InvestorProfile.objects.filter(user__email='investor@example.com').exists()
         )
 
-    def test_registration_duplicate_email_returns_409(self):
+    def test_registration_duplicate_email_returns_201_and_masks_existence(self):
+        existing_email = 'startup@example.com'
         User.objects.create_user(
-            username='startup@example.com',
-            email='startup@example.com',
+            username=existing_email,
+            email=existing_email,
             password='Password123!',
         )
+        initial_count = User.objects.count()
 
         response = self.client.post(self.url, self.valid_startup_data)
 
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data['detail'], 'A user with this email already exists.'
+            response.data['detail'], 'Verification email sent. Please check your inbox.'
         )
+        self.assertEqual(User.objects.count(), initial_count)
 
     def test_registration_weak_password_returns_400(self):
         data = self.valid_startup_data.copy()

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -1,11 +1,10 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
-from users.models import User
 from django.urls import reverse
+from investors.models import InvestorProfile
 from rest_framework import status
 from rest_framework.test import APIClient
-from django.contrib.auth import get_user_model
 from startups.models import StartupProfile
-from investors.models import InvestorProfile
 
 User = get_user_model()
 
@@ -13,16 +12,16 @@ User = get_user_model()
 class UserModelTests(TestCase):
     def test_user_creation_with_role_flags(self):
         user = User.objects.create_user(
-            username="testuser",
-            email="test@example.com",
-            password="123qwe!@#",
+            username='testuser',
+            email='test@example.com',
+            password='123qwe!@#',
             is_startup=True,
             is_investor=False,
             is_verified=True,
         )
 
-        self.assertEqual(user.username, "testuser")
-        self.assertEqual(user.email, "test@example.com")
+        self.assertEqual(user.username, 'testuser')
+        self.assertEqual(user.email, 'test@example.com')
         self.assertTrue(user.is_startup)
         self.assertFalse(user.is_investor)
         self.assertTrue(user.is_verified)
@@ -33,47 +32,53 @@ class RegistrationAPITests(TestCase):
         self.client = APIClient()
         self.url = reverse('register')
         self.valid_startup_data = {
-            "email": "startup@example.com",
-            "password": "StrongPassword123!",
-            "role": "startup",
-            "company_name": "Tech Future",
-            "short_pitch": "We build AI solutions."
+            'email': 'startup@example.com',
+            'password': 'StrongPassword123!',
+            'role': 'startup',
+            'company_name': 'Tech Future',
+            'short_pitch': 'We build AI solutions.',
         }
 
     def test_successful_startup_registration(self):
         response = self.client.post(self.url, self.valid_startup_data)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(User.objects.filter(email="startup@example.com").exists())
-        self.assertTrue(StartupProfile.objects.filter(company_name="Tech Future").exists())
+        self.assertTrue(User.objects.filter(email='startup@example.com').exists())
+        self.assertTrue(
+            StartupProfile.objects.filter(company_name='Tech Future').exists()
+        )
 
-        user = User.objects.get(email="startup@example.com")
+        user = User.objects.get(email='startup@example.com')
         self.assertFalse(user.is_active)
 
     def test_successful_investor_registration(self):
         data = {
-            "email": "investor@example.com",
-            "password": "StrongPassword123!",
-            "role": "investor",
-            "bio": "Experienced angel investor.",
-            "investment_focus": "SaaS"
+            'email': 'investor@example.com',
+            'password': 'StrongPassword123!',
+            'role': 'investor',
+            'bio': 'Experienced angel investor.',
+            'investment_focus': 'SaaS',
         }
         response = self.client.post(self.url, data)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(InvestorProfile.objects.filter(user__email="investor@example.com").exists())
+        self.assertTrue(
+            InvestorProfile.objects.filter(user__email='investor@example.com').exists()
+        )
 
     def test_registration_duplicate_email_returns_409(self):
         User.objects.create_user(
-            username="startup@example.com",
-            email="startup@example.com",
-            password="Password123!"
+            username='startup@example.com',
+            email='startup@example.com',
+            password='Password123!',
         )
 
         response = self.client.post(self.url, self.valid_startup_data)
 
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-        self.assertEqual(response.data['detail'], 'A user with this email already exists.')
+        self.assertEqual(
+            response.data['detail'], 'A user with this email already exists.'
+        )
 
     def test_registration_weak_password_returns_400(self):
         data = self.valid_startup_data.copy()

--- a/scalea/users/urls.py
+++ b/scalea/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import RegisterView
+
+urlpatterns = [
+    path('register/', RegisterView.as_view(), name='register'),
+]

--- a/scalea/users/urls.py
+++ b/scalea/users/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from .views import RegisterView
 
 urlpatterns = [

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -1,23 +1,27 @@
-from rest_framework import status, generics
-from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
 from django.contrib.auth import get_user_model
+from rest_framework import generics, status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
 from .serializers import RegisterSerializer
 
 User = get_user_model()
+
 
 class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer
     permission_classes = [AllowAny]
 
-    def create(self, request, *args, **kwargs):
-        email = request.data.get('email')
+    def create(self, request, *_args, **_kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
-        return Response({
-            "id": user.id,
-            "email": user.email,
-            "detail": "Verification email sent. Please check your inbox."
-        }, status=status.HTTP_201_CREATED)
+        return Response(
+            {
+                'id': user.id,
+                'email': user.email,
+                'detail': 'Verification email sent. Please check your inbox.',
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -19,7 +19,6 @@ class RegisterView(generics.CreateAPIView):
 
         return Response(
             {
-                'id': user.id,
                 'email': user.email,
                 'detail': 'Verification email sent. Please check your inbox.',
             },

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -1,3 +1,23 @@
-from django.shortcuts import render
+from rest_framework import status, generics
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+from django.contrib.auth import get_user_model
+from .serializers import RegisterSerializer
 
-# Create your views here.
+User = get_user_model()
+
+class RegisterView(generics.CreateAPIView):
+    serializer_class = RegisterSerializer
+    permission_classes = [AllowAny]
+
+    def create(self, request, *args, **kwargs):
+        email = request.data.get('email')
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+
+        return Response({
+            "id": user.id,
+            "email": user.email,
+            "detail": "Verification email sent. Please check your inbox."
+        }, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
**List of changes:**

- Unified Registration Endpoint: Developed a single POST /api/auth/register/ endpoint that handles both Startup and Investor registrations.

- Role-Based Logic: Integrated a role field in the request to dynamically validate and create either a StartupProfile or InvestorProfile linked to the user.

- Security & Status: Newly registered users are created with is_active=False status to ensure they cannot access the system before verification.
 
- Implemented server-side password validation to enforce security standards.

- Conflict Handling: 201 response for duplicate email attempts as part of the anti-enumeration strategy.

- Email Verification : Created a placeholder method send_verification_email(self, user) within the registration flow.
 
- Current status: The logic for generating unique tokens and sending actual emails is currently a stub (pass). This allows the registration process to function and return a 201 response while the mailing infrastructure is being finalized.
 
- Code Quality: All files have been processed with Ruff to ensure strict adherence to linting and formatting standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public user registration API with email normalization, password validation, role selection (startup or investor), and automatic role-specific profile creation.
  * Registration returns a verification-email message and creates inactive accounts pending verification.
  * Added auth routing under /api/auth/ including a register route.

* **Chores**
  * Several models now registered in the admin interface (User, StartupProfile, InvestorProfile).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->