### PR TITLE
[fix - 166]: disable automated dependabot PRs to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 0
     groups:
       python-deps:
         patterns: [ "*" ]
@@ -16,4 +18,5 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
**Summary:**  This PR adjusts the Dependabot configuration to resolve the issue of excessive PR noise. Automated updates for npm, pip, and github-actions are now set to monthly with an open-pull-requests-limit of 0.

**Why**: To clear the CI/CD queue and allow the team to focus on functional tasks. We can re-enable or adjust these limits once the current backlog of updates is cleared.

**Related Issue**: Closes #166 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to adjust update scheduling and limits for better control over automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->