### PR TITLE
fix: configure pytest-django and fix test discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dev = [
   "ruff==0.15.11",
   "pre-commit==4.5.1",
   "pytest",
-  "pytest-cov"
+  "pytest-cov",
+  "pytest-django"
 ]
 
 [tool.setuptools.packages.find]
@@ -67,3 +68,7 @@ mccabe.max-complexity = 10
 quote-style = "single"
 indent-style = "space"
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "scalea.settings"
+python_files = "tests.py test_*.py *_tests.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,4 +71,5 @@ line-ending = "auto"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "scalea.settings"
-python_files = "tests.py test_*.py *_tests.py"
+pythonpath = ["scalea"]
+python_files = ["tests.py", "test_*.py", "*_tests.py"]


### PR DESCRIPTION
Added pytest-django dependency and updated pyproject.toml to ensure pytest correctly finds and runs Django tests (including tests.py). This fixes the 0% coverage issue in Codecov.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added testing framework dependencies (`pytest-cov`, `pytest-django`) to development environment.
  * Configured pytest for Django integration with appropriate test discovery settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->