### PR TITLE
ticket #82 - feat(auth): implement password reset confirm endpoint (token + uid validation)

### DIFF
--- a/scalea/users/migrations/0004_passwordresetaudit_action_and_user_agent.py
+++ b/scalea/users/migrations/0004_passwordresetaudit_action_and_user_agent.py
@@ -1,0 +1,31 @@
+# Generated migration for PasswordResetAudit model updates
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0003_alter_passwordresetaudit_user'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='passwordresetaudit',
+            name='user_agent',
+            field=models.CharField(blank=True, default='', max_length=500),
+        ),
+        migrations.AddField(
+            model_name='passwordresetaudit',
+            name='action',
+            field=models.CharField(
+                choices=[
+                    ('requested', 'Password Reset Requested'),
+                    ('confirmed', 'Password Reset Confirmed'),
+                ],
+                default='requested',
+                help_text='Action performed: request or confirmation',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/scalea/users/migrations/0005_passwordresetaudit_action_and_user_agent.py
+++ b/scalea/users/migrations/0005_passwordresetaudit_action_and_user_agent.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('users', '0003_alter_passwordresetaudit_user'),
+        ('users', '0004_merge_20260508_1126'),
     ]
 
     operations = [

--- a/scalea/users/models.py
+++ b/scalea/users/models.py
@@ -23,6 +23,13 @@ class User(AbstractUser):
 
 
 class PasswordResetAudit(models.Model):
+    ACTION_REQUESTED = 'requested'
+    ACTION_CONFIRMED = 'confirmed'
+    ACTION_CHOICES = [
+        (ACTION_REQUESTED, 'Password Reset Requested'),
+        (ACTION_CONFIRMED, 'Password Reset Confirmed'),
+    ]
+
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -32,6 +39,13 @@ class PasswordResetAudit(models.Model):
     )
     email = models.EmailField(help_text='Електронна пошта, введена користувачем')
     ip_address = models.GenericIPAddressField(null=True, blank=True)
+    user_agent = models.CharField(max_length=500, blank=True, default='')
+    action = models.CharField(
+        max_length=20,
+        choices=ACTION_CHOICES,
+        default=ACTION_REQUESTED,
+        help_text='Action performed: request or confirmation',
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -40,4 +54,4 @@ class PasswordResetAudit(models.Model):
         ordering = ['-created_at']
 
     def __str__(self):
-        return f'Reset requested for {self.email} at {self.created_at.strftime("%Y-%m-%d %H:%M")}'
+        return f'{self.get_action_display()} for {self.email} at {self.created_at.strftime("%Y-%m-%d %H:%M")}'

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -19,11 +19,15 @@ class PasswordResetRequestSerializer(serializers.Serializer):
 
 
 class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
     token = serializers.CharField()
-    password = serializers.CharField(min_length=8)
+    password = serializers.CharField(min_length=8, write_only=True)
 
     def validate_password(self, value):
-        validate_password(value)
+        try:
+            validate_password(value)
+        except exceptions.ValidationError as e:
+            raise serializers.ValidationError(list(e.messages)) from e
         return value
 
 

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -161,9 +161,7 @@ class PasswordResetRequestTests(APITestCase):
     def test_audit_log_includes_user_agent(self):
         """Test that audit log captures user agent."""
         self.client.post(
-            self.url,
-            {'email': self.email},
-            HTTP_USER_AGENT='Mozilla/5.0 Test Browser'
+            self.url, {'email': self.email}, HTTP_USER_AGENT='Mozilla/5.0 Test Browser'
         )
 
         audit = PasswordResetAudit.objects.filter(

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -317,7 +317,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': '123',  # Too weak
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn('password', response.data)
 
     def test_common_password_returns_422(self):
@@ -330,7 +330,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': 'password123',  # Common password
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn('password', response.data)
 
     def test_numeric_password_returns_422(self):
@@ -343,7 +343,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': '12345678',  # All numeric
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self.assertIn('password', response.data)
 
     def test_missing_uid_returns_400(self):
@@ -369,7 +369,7 @@ class PasswordResetConfirmViewTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_missing_password_returns_400(self):
-        """Test that missing password returns 400."""
+        """Test that missing password returns 422 (validation error)."""
         response = self.client.post(
             self.url,
             {
@@ -377,7 +377,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'token': self.token,
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     def test_token_single_use_enforced_by_expiry(self):
         """Test that used token cannot be reused (enforced by token generator)."""
@@ -405,7 +405,7 @@ class PasswordResetConfirmViewTest(APITestCase):
 
     def test_user_can_login_with_new_password_after_reset(self):
         """Test that user can login with new password after reset."""
-        self.client.post(
+        response = self.client.post(
             self.url,
             {
                 'uid': self.uid,
@@ -413,9 +413,12 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': 'NewP@ssword1',
             },
         )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         
-        # Activate user so they can login
+        # Refresh user from database and activate
+        self.user.refresh_from_db()
         self.user.is_active = True
+        self.user.is_verified = True
         self.user.is_startup = True
         self.user.save()
         

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -156,7 +156,6 @@ class PasswordResetRequestTests(APITestCase):
         self.assertEqual(audit.user, self.user)
         self.assertEqual(audit.email, self.email)
         self.assertIsNotNone(audit.ip_address)
-        self.assertNotEqual(audit.user_agent, '')
 
     def test_audit_log_includes_user_agent(self):
         """Test that audit log captures user agent."""
@@ -366,8 +365,8 @@ class PasswordResetConfirmViewTest(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_missing_password_returns_422(self):
-        """Test that missing password returns 422 (validation error)."""
+    def test_missing_password_returns_400(self):
+        """Test that missing password returns 400 (malformed request)."""
         response = self.client.post(
             self.url,
             {
@@ -375,7 +374,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'token': self.token,
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_token_single_use_enforced_by_expiry(self):
         """Test that used token cannot be reused (enforced by token generator)."""

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -142,14 +142,14 @@ class PasswordResetRequestTests(APITestCase):
         initial_count = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_REQUESTED
         ).count()
-        
+
         self.client.post(self.url, {'email': self.email})
-        
+
         new_count = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_REQUESTED
         ).count()
         self.assertEqual(new_count, initial_count + 1)
-        
+
         audit = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_REQUESTED
         ).latest('created_at')
@@ -165,7 +165,7 @@ class PasswordResetRequestTests(APITestCase):
             {'email': self.email},
             HTTP_USER_AGENT='Mozilla/5.0 Test Browser'
         )
-        
+
         audit = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_REQUESTED
         ).latest('created_at')
@@ -203,7 +203,7 @@ class PasswordResetConfirmViewTest(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['detail'], 'Password changed successfully.')
-        
+
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password('NewP@ssword1'))
 
@@ -212,7 +212,7 @@ class PasswordResetConfirmViewTest(APITestCase):
         initial_count = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_CONFIRMED
         ).count()
-        
+
         self.client.post(
             self.url,
             {
@@ -221,12 +221,12 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': 'NewP@ssword1',
             },
         )
-        
+
         new_count = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_CONFIRMED
         ).count()
         self.assertEqual(new_count, initial_count + 1)
-        
+
         audit = PasswordResetAudit.objects.filter(
             action=PasswordResetAudit.ACTION_CONFIRMED
         ).latest('created_at')
@@ -246,7 +246,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': 'NewP@ssword1',
             },
         )
-        
+
         refresh_response = self.client.post(
             '/api/auth/refresh/',
             {'refresh': refresh},
@@ -390,7 +390,7 @@ class PasswordResetConfirmViewTest(APITestCase):
                 'password': 'NewP@ssword1',
             },
         )
-        
+
         # Django's PasswordResetTokenGenerator automatically invalidates
         # tokens after first use by checking password_changed_date
         response = self.client.post(
@@ -414,14 +414,14 @@ class PasswordResetConfirmViewTest(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
+
         # Refresh user from database and activate
         self.user.refresh_from_db()
         self.user.is_active = True
         self.user.is_verified = True
         self.user.is_startup = True
         self.user.save()
-        
+
         login_response = self.client.post(
             '/api/auth/login/',
             {

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -366,7 +366,7 @@ class PasswordResetConfirmViewTest(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_missing_password_returns_400(self):
+    def test_missing_password_returns_422(self):
         """Test that missing password returns 422 (validation error)."""
         response = self.client.post(
             self.url,

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -137,10 +137,39 @@ class PasswordResetRequestTests(APITestCase):
         response = self.client.post(self.url, {'email': 'notanemail'})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_audit_log_created(self):
-        initial_count = PasswordResetAudit.objects.count()
+    def test_audit_log_created_for_request(self):
+        """Test that password reset request creates audit log entry."""
+        initial_count = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_REQUESTED
+        ).count()
+        
         self.client.post(self.url, {'email': self.email})
-        self.assertEqual(PasswordResetAudit.objects.count(), initial_count + 1)
+        
+        new_count = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_REQUESTED
+        ).count()
+        self.assertEqual(new_count, initial_count + 1)
+        
+        audit = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_REQUESTED
+        ).latest('created_at')
+        self.assertEqual(audit.user, self.user)
+        self.assertEqual(audit.email, self.email)
+        self.assertIsNotNone(audit.ip_address)
+        self.assertNotEqual(audit.user_agent, '')
+
+    def test_audit_log_includes_user_agent(self):
+        """Test that audit log captures user agent."""
+        self.client.post(
+            self.url,
+            {'email': self.email},
+            HTTP_USER_AGENT='Mozilla/5.0 Test Browser'
+        )
+        
+        audit = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_REQUESTED
+        ).latest('created_at')
+        self.assertIn('Mozilla', audit.user_agent)
 
     def test_throttling_applies(self):
         for _ in range(5):
@@ -160,58 +189,247 @@ class PasswordResetConfirmViewTest(APITestCase):
         )
         self.uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         self.token = password_reset_token.make_token(self.user)
-        self.combined_token = f'{self.uid}.{self.token}'
         self.url = '/api/auth/password-reset/confirm/'
 
-    def test_valid_token_changes_password(self):
+    def test_valid_token_and_uid_changes_password(self):
+        """Test that valid uid and token successfully reset password."""
         response = self.client.post(
             self.url,
             {
-                'token': self.combined_token,
+                'uid': self.uid,
+                'token': self.token,
                 'password': 'NewP@ssword1',
             },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['detail'], 'Password changed successfully.')
+        
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password('NewP@ssword1'))
 
+    def test_password_reset_creates_audit_log(self):
+        """Test that password reset confirmation creates an audit log entry."""
+        initial_count = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_CONFIRMED
+        ).count()
+        
+        self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': 'NewP@ssword1',
+            },
+        )
+        
+        new_count = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_CONFIRMED
+        ).count()
+        self.assertEqual(new_count, initial_count + 1)
+        
+        audit = PasswordResetAudit.objects.filter(
+            action=PasswordResetAudit.ACTION_CONFIRMED
+        ).latest('created_at')
+        self.assertEqual(audit.user, self.user)
+        self.assertEqual(audit.email, self.user.email)
+        self.assertIsNotNone(audit.ip_address)
+
     def test_password_reset_revokes_existing_refresh_tokens(self):
+        """Test that refresh tokens are revoked after password reset."""
         refresh = str(RefreshToken.for_user(self.user))
 
         self.client.post(
             self.url,
             {
-                'token': self.combined_token,
+                'uid': self.uid,
+                'token': self.token,
                 'password': 'NewP@ssword1',
             },
         )
+        
         refresh_response = self.client.post(
             '/api/auth/refresh/',
             {'refresh': refresh},
             format='json',
         )
-
         self.assertEqual(refresh_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_invalid_token_returns_400(self):
+        """Test that invalid token returns 400."""
         response = self.client.post(
             self.url,
             {
-                'token': f'{self.uid}.invalid-token-123',
+                'uid': self.uid,
+                'token': 'invalid-token-123',
+                'password': 'NewP@ssword1',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['detail'], 'Invalid or expired token.')
+
+    def test_expired_token_returns_400(self):
+        """Test that expired token returns 400."""
+        # Create a user with an old timestamp to simulate token expiry
+        with patch('users.tokens.password_reset_token.check_token', return_value=False):
+            response = self.client.post(
+                self.url,
+                {
+                    'uid': self.uid,
+                    'token': self.token,
+                    'password': 'NewP@ssword1',
+                },
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_uid_returns_400(self):
+        """Test that invalid uid returns 400."""
+        response = self.client.post(
+            self.url,
+            {
+                'uid': 'invaliduid',
+                'token': self.token,
+                'password': 'NewP@ssword1',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['detail'], 'Invalid or expired token.')
+
+    def test_nonexistent_user_returns_400(self):
+        """Test that nonexistent user ID returns 400."""
+        invalid_uid = urlsafe_base64_encode(force_bytes(999999))
+        response = self.client.post(
+            self.url,
+            {
+                'uid': invalid_uid,
+                'token': self.token,
                 'password': 'NewP@ssword1',
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_invalid_uid_returns_400(self):
+    def test_weak_password_returns_422(self):
+        """Test that weak password returns 422."""
         response = self.client.post(
             self.url,
             {
-                'token': f'invaliduid.{self.token}',
+                'uid': self.uid,
+                'token': self.token,
+                'password': '123',  # Too weak
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('password', response.data)
+
+    def test_common_password_returns_422(self):
+        """Test that common password returns 422."""
+        response = self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': 'password123',  # Common password
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('password', response.data)
+
+    def test_numeric_password_returns_422(self):
+        """Test that all-numeric password returns 422."""
+        response = self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': '12345678',  # All numeric
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('password', response.data)
+
+    def test_missing_uid_returns_400(self):
+        """Test that missing uid returns 400."""
+        response = self.client.post(
+            self.url,
+            {
+                'token': self.token,
                 'password': 'NewP@ssword1',
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_token_returns_400(self):
+        """Test that missing token returns 400."""
+        response = self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'password': 'NewP@ssword1',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_password_returns_400(self):
+        """Test that missing password returns 400."""
+        response = self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_token_single_use_enforced_by_expiry(self):
+        """Test that used token cannot be reused (enforced by token generator)."""
+        # First use
+        self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': 'NewP@ssword1',
+            },
+        )
+        
+        # Django's PasswordResetTokenGenerator automatically invalidates
+        # tokens after first use by checking password_changed_date
+        response = self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': 'AnotherNew@ssw0rd2',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_user_can_login_with_new_password_after_reset(self):
+        """Test that user can login with new password after reset."""
+        self.client.post(
+            self.url,
+            {
+                'uid': self.uid,
+                'token': self.token,
+                'password': 'NewP@ssword1',
+            },
+        )
+        
+        # Activate user so they can login
+        self.user.is_active = True
+        self.user.is_startup = True
+        self.user.save()
+        
+        login_response = self.client.post(
+            '/api/auth/login/',
+            {
+                'email': self.user.email,
+                'password': 'NewP@ssword1',
+                'role': 'startup',
+            },
+        )
+        self.assertEqual(login_response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', login_response.data)
+        self.assertIn('refresh', login_response.data)
 
 
 class TestLoginApi(APITestCase):

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -125,16 +125,27 @@ class PasswordResetConfirmView(APIView):
 
     def post(self, request):
         serializer = PasswordResetConfirmSerializer(data=request.data)
-        if not serializer.is_valid():
-            # Return 422 for password validation errors
-            if 'password' in serializer.errors:
+        serializer.is_valid()
+
+        # Separate validation errors: required/malformed (400) vs weak password (422)
+        errors = serializer.errors
+        if errors:
+            # Check if password errors are from validate_password() (weak password)
+            password_errors = errors.get('password', [])
+            is_weak_password = any(
+                error.code != 'required' and error.code != 'blank'
+                for error in password_errors
+            )
+
+            if is_weak_password:
+                # 422 for password complexity/validation errors only
                 return Response(
-                    serializer.errors,
+                    errors,
                     status=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 )
-            # Return 400 for other validation errors (uid, token)
+            # 400 for malformed requests (missing fields, invalid uid/token format)
             return Response(
-                serializer.errors,
+                errors,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -144,9 +155,13 @@ class PasswordResetConfirmView(APIView):
 
         try:
             uid = force_str(urlsafe_base64_decode(uid_b64))
-            user = User.objects.filter(id=uid).first()
         except (ValueError, TypeError):
-            user = None
+            return Response(
+                {'detail': 'Invalid or expired token.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = User.objects.filter(id=uid).first()
 
         if not user or not password_reset_token.check_token(user, token):
             return Response(

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -125,7 +125,18 @@ class PasswordResetConfirmView(APIView):
 
     def post(self, request):
         serializer = PasswordResetConfirmSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+        if not serializer.is_valid():
+            # Return 422 for password validation errors
+            if 'password' in serializer.errors:
+                return Response(
+                    serializer.errors,
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                )
+            # Return 400 for other validation errors (uid, token)
+            return Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         uid_b64 = serializer.validated_data['uid']
         token = serializer.validated_data['token']

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -153,6 +153,7 @@ class PasswordResetConfirmView(APIView):
         token = serializer.validated_data['token']
         password = serializer.validated_data['password']
 
+        # Decode UID separately - handles base64 decoding errors
         try:
             uid = force_str(urlsafe_base64_decode(uid_b64))
         except (ValueError, TypeError):
@@ -161,9 +162,17 @@ class PasswordResetConfirmView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        user = User.objects.filter(id=uid).first()
+        # Lookup user separately - handles non-existent user
+        try:
+            user = User.objects.get(id=uid)
+        except (User.DoesNotExist, ValueError):
+            return Response(
+                {'detail': 'Invalid or expired token.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        if not user or not password_reset_token.check_token(user, token):
+        # Validate token
+        if not password_reset_token.check_token(user, token):
             return Response(
                 {'detail': 'Invalid or expired token.'},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -79,14 +79,17 @@ class PasswordResetRequestView(APIView):
         user = User.objects.filter(email=email).first()
 
         PasswordResetAudit.objects.create(
-            user=user, email=email, ip_address=get_client_ip(request)
+            user=user,
+            email=email,
+            ip_address=get_client_ip(request),
+            user_agent=request.META.get('HTTP_USER_AGENT', '')[:500],
+            action=PasswordResetAudit.ACTION_REQUESTED,
         )
 
         if user:
             token = password_reset_token.make_token(user)
             uid = urlsafe_base64_encode(force_bytes(user.pk))
-            combined_token = f'{uid}.{token}'
-            reset_url = f'{settings.FRONTEND_URL}/reset-password/{combined_token}/'
+            reset_url = f'{settings.FRONTEND_URL}/reset-password/{uid}/{token}/'
 
             html_message = render_to_string(
                 'email/password_reset.html',
@@ -124,11 +127,11 @@ class PasswordResetConfirmView(APIView):
         serializer = PasswordResetConfirmSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        raw_token = serializer.validated_data['token']
+        uid_b64 = serializer.validated_data['uid']
+        token = serializer.validated_data['token']
         password = serializer.validated_data['password']
 
         try:
-            uid_b64, token = raw_token.split('.', 1)
             uid = force_str(urlsafe_base64_decode(uid_b64))
             user = User.objects.filter(id=uid).first()
         except (ValueError, TypeError):
@@ -136,7 +139,7 @@ class PasswordResetConfirmView(APIView):
 
         if not user or not password_reset_token.check_token(user, token):
             return Response(
-                {'detail': 'Invalid or expired token'},
+                {'detail': 'Invalid or expired token.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -144,13 +147,23 @@ class PasswordResetConfirmView(APIView):
             user.set_password(password)
             user.save()
 
+            # Revoke all outstanding refresh tokens
             for outstanding in OutstandingToken.objects.filter(user=user):
                 BlacklistedToken.objects.get_or_create(token=outstanding)
 
-        logger.info('Password reset successful for user ID: %s', user.pk)
+            # Log the password reset confirmation
+            PasswordResetAudit.objects.create(
+                user=user,
+                email=user.email,
+                ip_address=get_client_ip(request),
+                user_agent=request.META.get('HTTP_USER_AGENT', '')[:500],
+                action=PasswordResetAudit.ACTION_CONFIRMED,
+            )
+
+        logger.info('Password reset confirmed for user ID: %s', user.pk)
 
         return Response(
-            {'detail': 'Password changed successfully'},
+            {'detail': 'Password changed successfully.'},
             status=status.HTTP_200_OK,
         )
 


### PR DESCRIPTION
### Ticket #82 

## Implemented password reset confirmation endpoint with token and UID validation.

## What was done
* Added POST /api/auth/password-reset/confirm/ endpoint
* Implemented validation:
    * UID decoding and verification
    * token validation (expiry + single-use enforcement)
* Updated password securely using set_password()
* Revoked active sessions / refresh tokens after password change
* Added audit log entry for password reset action
* Enforced password complexity rules (aligned with registration)
* Response handling:
    * 200 — password changed successfully
    * 400 — invalid or expired token
    * 422 — weak password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logging for password reset events now records action (requested/confirmed) and user agent; reset link format changed to separate uid and token segments.

* **Bug Fixes**
  * Improved validation error mapping and messaging for password reset confirmation (distinct 400/422 handling) and consistent password validation errors; ensures refresh tokens are revoked on successful reset.

* **Tests**
  * Expanded and hardened tests for request/confirmation flows, audit entries, token edge cases, and password-strength validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ITA-Dnipro/UA-4544/pull/181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->