### PR TITLE
[BE -186]: implement org-admin auth and login

### DIFF
--- a/scalea/users/migrations/0005_userrolecredential.py
+++ b/scalea/users/migrations/0005_userrolecredential.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0004_merge_20260508_1126'),
+    ]
+
+    operations = []

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -59,6 +59,10 @@ class RegisterSerializer(serializers.Serializer):
         user = User.objects.filter(email=email).first()
 
         if user:
+            if not user.check_password(password):
+                self.send_already_registered_email(user)
+                return user
+
             if (
                 (role == 'startup' and user.is_startup)
                 or (role == 'investor' and user.is_investor)
@@ -67,10 +71,6 @@ class RegisterSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     {'role': f'You already have a {role} profile.'}
                 )
-
-            if not user.check_password(password):
-                self.send_already_registered_email(user)
-                return user
 
             if role == 'startup':
                 user.is_startup = True
@@ -151,6 +151,12 @@ class LoginSerializer(serializers.Serializer):
                 code='authorization',
             )
 
+        if not user.check_password(password):
+            raise serializers.ValidationError(
+                {'detail': 'Invalid email or password.'},
+                code='authorization',
+            )
+
         role_check = {
             'startup': user.is_startup,
             'investor': user.is_investor,
@@ -158,10 +164,6 @@ class LoginSerializer(serializers.Serializer):
         }
 
         if not role_check.get(requested_role):
-            raise serializers.ValidationError(
-                {'detail': f'Your account does not have {requested_role} permissions.'}
-            )
-        if not user.check_password(password):
             raise serializers.ValidationError(
                 {'detail': 'Invalid email or password.'},
                 code='authorization',

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -30,7 +30,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True, min_length=8)
-    role = serializers.ChoiceField(choices=['startup', 'investor'])
+    role = serializers.ChoiceField(choices=['startup', 'investor', 'org_admin'])
     company_name = serializers.CharField(required=False, allow_blank=True, default='')
     short_pitch = serializers.CharField(required=False, allow_blank=True, default='')
     website = serializers.URLField(required=False, allow_blank=True, default='')
@@ -59,35 +59,63 @@ class RegisterSerializer(serializers.Serializer):
         user = User.objects.filter(email=email).first()
 
         if user:
-            self.send_already_registered_email(user)
-            return user
+            if (
+                (role == 'startup' and user.is_startup)
+                or (role == 'investor' and user.is_investor)
+                or (role == 'org_admin' and user.is_org_admin)
+            ):
+                raise serializers.ValidationError(
+                    {'role': f'You already have a {role} profile.'}
+                )
 
-        user = User.objects.create_user(
-            username=email,
-            email=email,
-            password=password,
-            is_active=False,
-            is_startup=(role == 'startup'),
-            is_investor=(role == 'investor'),
-        )
+            if not user.check_password(password):
+                self.send_already_registered_email(user)
+                return user
 
-        if role == 'startup':
-            StartupProfile.objects.create(
-                user=user,
-                company_name=validated_data.get('company_name', ''),
-                description=validated_data.get('short_pitch', ''),
-                website=validated_data.get('website', ''),
-            )
+            if role == 'startup':
+                user.is_startup = True
+            elif role == 'investor':
+                user.is_investor = True
+            elif role == 'org_admin':
+                user.is_org_admin = True
+                user.is_verified = False
+
+            user.save()
         else:
-            InvestorProfile.objects.create(
-                user=user,
-                company_name=validated_data.get('company_name', ''),
-                bio=validated_data.get('bio', ''),
-                investment_focus=validated_data.get('investment_focus', ''),
+            user = User.objects.create_user(
+                username=email,
+                email=email,
+                password=password,
+                is_active=False,
+                is_startup=(role == 'startup'),
+                is_investor=(role == 'investor'),
+                is_org_admin=(role == 'org_admin'),
             )
+
+        self._create_role_profile(user, role, validated_data)
 
         self.send_verification_email(user)
         return user
+
+    def _create_role_profile(self, user, role, data):
+        if role == 'startup':
+            StartupProfile.objects.get_or_create(
+                user=user,
+                defaults={
+                    'company_name': data.get('company_name', ''),
+                    'description': data.get('short_pitch', ''),
+                    'website': data.get('website', ''),
+                },
+            )
+        elif role == 'investor':
+            InvestorProfile.objects.get_or_create(
+                user=user,
+                defaults={
+                    'company_name': data.get('company_name', ''),
+                    'bio': data.get('bio', ''),
+                    'investment_focus': data.get('investment_focus', ''),
+                },
+            )
 
     def send_verification_email(self, user):
         # TODO(i-taras): Implement actual SMTP dispatch & activation token logic [#99]
@@ -107,21 +135,37 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True, trim_whitespace=False)
     remember = serializers.BooleanField(required=False, default=False)
-    role = serializers.ChoiceField(choices=['startup', 'investor'], required=True)
+    role = serializers.ChoiceField(
+        choices=['startup', 'investor', 'org_admin'], required=True
+    )
 
     def validate(self, attrs):
         email = attrs['email'].strip().lower()
         password = attrs['password']
         requested_role = attrs['role']
-
         user = User.objects.filter(email=email).first()
 
-        if not user or not user.check_password(password) or not user.is_active:
+        if not user or not user.is_active:
             raise serializers.ValidationError(
                 {'detail': 'Invalid email or password.'},
                 code='authorization',
             )
 
+        role_check = {
+            'startup': user.is_startup,
+            'investor': user.is_investor,
+            'org_admin': user.is_org_admin,
+        }
+
+        if not role_check.get(requested_role):
+            raise serializers.ValidationError(
+                {'detail': f'Your account does not have {requested_role} permissions.'}
+            )
+        if not user.check_password(password):
+            raise serializers.ValidationError(
+                {'detail': 'Invalid email or password.'},
+                code='authorization',
+            )
         if requested_role == 'startup' and not user.is_startup:
             raise serializers.ValidationError(
                 {'detail': 'Invalid email or password.'},

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -148,11 +148,12 @@ class RegistrationAPITests(TestCase):
         self.assertTrue(user.is_investor)
 
     def test_registration_same_role_twice_returns_400(self):
+        existing_password = 'StrongPassword123!'
         self.client.post(
             self.url,
             {
                 'email': 'startup-role@example.com',
-                'password': 'StrongPassword123!',
+                'password': existing_password,
                 'role': 'startup',
             },
         )
@@ -161,7 +162,7 @@ class RegistrationAPITests(TestCase):
             self.url,
             {
                 'email': 'startup-role@example.com',
-                'password': 'AnotherStrongPass123!',
+                'password': existing_password,
                 'role': 'startup',
             },
         )

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -9,12 +9,12 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from investors.models import InvestorProfile
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
-
-from investors.models import InvestorProfile
 from startups.models import StartupProfile
+
 from users.tokens import password_reset_token
 
 from .models import PasswordResetAudit
@@ -117,6 +117,56 @@ class RegistrationAPITests(TestCase):
 
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_registration_same_email_can_add_second_role(self):
+        password = 'StrongPassword123!'
+
+        first_response = self.client.post(
+            self.url,
+            {
+                'email': 'multirole@example.com',
+                'password': password,
+                'role': 'startup',
+                'company_name': 'Role One',
+            },
+        )
+        self.assertEqual(first_response.status_code, status.HTTP_201_CREATED)
+
+        second_response = self.client.post(
+            self.url,
+            {
+                'email': 'multirole@example.com',
+                'password': password,
+                'role': 'investor',
+                'bio': 'Role two profile',
+            },
+        )
+        self.assertEqual(second_response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(email='multirole@example.com')
+        self.assertTrue(user.is_startup)
+        self.assertTrue(user.is_investor)
+
+    def test_registration_same_role_twice_returns_400(self):
+        self.client.post(
+            self.url,
+            {
+                'email': 'startup-role@example.com',
+                'password': 'StrongPassword123!',
+                'role': 'startup',
+            },
+        )
+
+        response = self.client.post(
+            self.url,
+            {
+                'email': 'startup-role@example.com',
+                'password': 'AnotherStrongPass123!',
+                'role': 'startup',
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('role', response.data)
 
 
 class PasswordResetRequestTests(APITestCase):
@@ -334,6 +384,27 @@ class TestLoginApi(APITestCase):
         self.assertEqual(res.data['user']['email'], self.email)
         self.assertEqual(res.data['user']['role'], 'startup')
 
+    def test_unverified_org_admin_login_returns_403_pending_approval(self):
+        self.user.is_org_admin = True
+        self.user.is_verified = False
+        self.user.save(update_fields=['is_org_admin', 'is_verified'])
+
+        res = self.client.post(
+            self.url,
+            {
+                'email': self.email,
+                'password': self.password,
+                'role': 'org_admin',
+            },
+            format='json',
+        )
+
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            res.data.get('detail'),
+            'Your administrative account is pending approval.',
+        )
+
     def test_wrong_password_returns_401_generic(self):
         res = self.client.post(
             self.url,
@@ -520,3 +591,37 @@ class RefreshAndLogoutApiTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('detail', response.data)
+
+    def test_logout_startup_session_still_allows_login_as_investor(self):
+        same_password = self.password
+        register_url = reverse('register')
+
+        register_response = self.client.post(
+            register_url,
+            {
+                'email': self.user.email,
+                'password': same_password,
+                'role': 'investor',
+                'bio': 'Investor role profile',
+            },
+            format='json',
+        )
+        self.assertEqual(register_response.status_code, status.HTTP_201_CREATED)
+
+        logout_response = self.client.post(
+            self.logout_url,
+            {'refresh': self.refresh_token},
+            format='json',
+        )
+        self.assertEqual(logout_response.status_code, status.HTTP_204_NO_CONTENT)
+
+        investor_login_response = self.client.post(
+            reverse('auth-login'),
+            {
+                'email': self.user.email,
+                'password': same_password,
+                'role': 'investor',
+            },
+            format='json',
+        )
+        self.assertEqual(investor_login_response.status_code, status.HTTP_200_OK)

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -12,6 +12,11 @@ from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from investors.models import InvestorProfile
+from investors.serializers import (
+    InvestorProfileUpdateSerializer,
+    InvestorPublicProfileSerializer,
+)
 from rest_framework import generics, status
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import SAFE_METHODS, AllowAny
@@ -24,12 +29,6 @@ from rest_framework_simplejwt.token_blacklist.models import (
 )
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView
-
-from investors.models import InvestorProfile
-from investors.serializers import (
-    InvestorProfileUpdateSerializer,
-    InvestorPublicProfileSerializer,
-)
 from startups.models import StartupProfile
 from startups.permissions import IsProfileOwnerOrAdmin
 from startups.serializers import (
@@ -222,6 +221,13 @@ class LoginView(APIView):
 
         user = serializer.validated_data['user']
         remember = serializer.validated_data['remember']
+        role = serializer.validated_data.get('role')
+
+        if role == 'org_admin' and not user.is_verified:
+            return Response(
+                {'detail': 'Your administrative account is pending approval.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         clear_failures(email)
 
@@ -239,7 +245,7 @@ class LoginView(APIView):
                 'user': {
                     'id': user.id,
                     'email': user.email,
-                    'role': serializer.validated_data.get('role'),
+                    'role': role,
                 },
             },
             status=status.HTTP_200_OK,


### PR DESCRIPTION

**Closes**: https://github.com/ITA-Dnipro/UA-4544/issues/186

**Changes**:
  * Added support for `org_admin` user role in registration and login flows
  * Users can now register with multiple roles using the same email address
  * Org admin accounts require approval before gaining login access

 **Tests**:
  * Expanded test coverage for multi-role registration and login scenarios
  * Added validation tests for org admin account approval requirements
  
**Check**: Automated tests

```docker compose exec backend python manage.py test users```