### PR TITLE
BE-67/Security/Ops

### DIFF
--- a/docs/security/registration.md
+++ b/docs/security/registration.md
@@ -29,8 +29,6 @@ The registration endpoint (`POST /api/auth/register/`) is protected by:
 
 ## 2. Rate Limiting
 
-## 2. Rate Limiting
-
 ### 2a. Per-IP throttling (DRF ScopedRateThrottle)
 
 Configured in `settings.py` via `DEFAULT_THROTTLE_RATES`:
@@ -54,7 +52,7 @@ Implemented via `users/security.py`:
 |---|---|---|
 | `POST /api/auth/register/` | 5 attempts / hour per email | 1 hour |
 
-- Counted: `record_register_attempt(email)` — after successful captcha only
+- Counted: `record_register_attempt(email)` — only on failed registration attempts (serializer validation error)
 - Checked: `is_register_locked(email)` — at the very start of the request
 - Active only when `RECAPTCHA_SECRET_KEY` is set (production)
 - Uses cache keys `auth:register:count:{email}` and `auth:register:lock:{email}`

--- a/docs/security/registration.md
+++ b/docs/security/registration.md
@@ -29,6 +29,10 @@ The registration endpoint (`POST /api/auth/register/`) is protected by:
 
 ## 2. Rate Limiting
 
+## 2. Rate Limiting
+
+### 2a. Per-IP throttling (DRF ScopedRateThrottle)
+
 Configured in `settings.py` via `DEFAULT_THROTTLE_RATES`:
 
 | Endpoint | Scope | Limit |
@@ -42,7 +46,19 @@ Cache backend: Django default cache (LocMemCache in dev)
 
 When limit is exceeded → `429 Too Many Requests`
 
----
+### 2b. Per-email throttling (registration)
+
+Implemented via `users/security.py`:
+
+| Endpoint | Limit | Lockout |
+|---|---|---|
+| `POST /api/auth/register/` | 5 attempts / hour per email | 1 hour |
+
+- Counted: `record_register_attempt(email)` — after successful captcha only
+- Checked: `is_register_locked(email)` — at the very start of the request
+- Active only when `RECAPTCHA_SECRET_KEY` is set (production)
+- Uses cache keys `auth:register:count:{email}` and `auth:register:lock:{email}`
+- Separate from login per-email protection (`auth:login:*` keys)
 
 ## 3. CORS Policy
 

--- a/docs/security/registration.md
+++ b/docs/security/registration.md
@@ -1,0 +1,104 @@
+# Registration Security Runbook
+
+## Overview
+
+The registration endpoint (`POST /api/auth/register/`) is protected by:
+1. **reCAPTCHA v2** — bot mitigation via Google's "I'm not a robot" checkbox
+2. **Rate limiting** — per-IP throttle via Django REST Framework
+3. **CORS policy** — only allowed frontend origins can make requests
+
+---
+
+## 1. Bot Protection — reCAPTCHA v2
+
+**How it works:**
+- Frontend renders a Google reCAPTCHA v2 widget (checkbox "I'm not a robot")
+- On submit, the frontend includes a `recaptcha_token` in the POST body
+- Backend verifies the token against Google's `siteverify` API using `RECAPTCHA_SECRET_KEY`
+- If verification fails → `400 Bad Request` with `{"detail": "Invalid captcha. Please try again."}`
+- If `RECAPTCHA_SECRET_KEY` is empty (local dev without key) → verification is skipped
+
+**Frontend component:** `react-google-recaptcha`
+**Site key env var:** `VITE_RECAPTCHA_SITE_KEY` (frontend `.env`)
+**Secret key env var:** `RECAPTCHA_SECRET_KEY` (backend `.env`)
+
+> ⚠️ For local development, use Google's public test keys (always pass).
+> For production, register real keys at https://www.google.com/recaptcha/admin
+
+---
+
+## 2. Rate Limiting
+
+Configured in `settings.py` via `DEFAULT_THROTTLE_RATES`:
+
+| Endpoint | Scope | Limit |
+|---|---|---|
+| `POST /api/auth/register/` | `register` | 5 requests / hour per IP |
+| `POST /api/auth/login/` | `login` | 10 requests / hour per IP |
+| `POST /api/auth/password-reset/` | `password_reset` | 5 requests / hour per IP |
+
+Throttle class: `ScopedRateThrottle` (DRF built-in)
+Cache backend: Django default cache (LocMemCache in dev)
+
+When limit is exceeded → `429 Too Many Requests`
+
+---
+
+## 3. CORS Policy
+
+Only the configured frontend origin(s) are allowed to make API requests from the browser.
+
+**Config:** `CORS_ALLOWED_ORIGINS` in `settings.py` (read from `.env`)
+**Default (dev):** `http://localhost:5173, http://127.0.0.1:5173, http://frontend:5173`
+**Production:** set `CORS_ALLOWED_ORIGINS` in CI/CD secrets or server environment
+
+> ℹ️ CORS only restricts browser-based requests. Server-to-server calls are not blocked by CORS.
+> Rate limiting and reCAPTCHA cover non-browser attack vectors.
+
+---
+
+## 4. Required Environment Variables
+
+### Backend (`scalea/.env`)
+
+| Variable | Description | Where to get |
+|---|---|---|
+| `RECAPTCHA_SECRET_KEY` | reCAPTCHA v2 secret key for server-side verification | https://www.google.com/recaptcha/admin |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed frontend origins | Set per environment |
+
+### Frontend (`frontend/.env`)
+
+| Variable | Description | Where to get |
+|---|---|---|
+| `VITE_RECAPTCHA_SITE_KEY` | reCAPTCHA v2 public site key for widget rendering | https://www.google.com/recaptcha/admin |
+
+> For local development, use Google's public test keys (see `.env.example` files).
+
+---
+
+## 5. Monitoring & Alerting
+
+### Unusual Signup Spikes
+**Trigger:** More than 50 registration attempts within 5 minutes from various IPs
+
+**Actions:**
+1. Check server logs: `grep "POST /api/auth/register/" access.log | tail -100`
+2. Identify suspicious IPs and block at nginx/firewall level
+3. Temporarily tighten rate limit: change `'register': '5/hour'` to `'register': '2/hour'`
+4. Notify DevOps if attack is ongoing
+
+### High Email Bounce Rate
+**Trigger:** Email bounce rate > 10% (emails rejected by recipients' mail servers)
+
+**What it means:** Bots are registering with fake/non-existent emails, causing your email provider to flag your account as spam.
+
+**Actions:**
+1. Check bounce reports in your email provider dashboard (Gmail, SendGrid, etc.)
+2. If rate > 10%: tighten reCAPTCHA (switch to invisible reCAPTCHA or add email domain validation)
+3. If rate > 30%: contact email provider support to avoid account suspension
+4. Consider adding email existence verification (MX record check) before sending
+
+### Resend Verification Abuse
+**Trigger:** Same email requesting resend > 3 times / hour
+
+**Actions:** Rate limit on `/api/auth/resend-verification/` is handled in task #99 (i-taras).

--- a/env.example
+++ b/env.example
@@ -21,3 +21,10 @@ EMAIL_HOST_PASSWORD=your-app-password
 DEFAULT_FROM_EMAIL=example@gmail.com
 
 FRONTEND_URL=http://localhost:5173
+
+# Security (required for registration protection)
+# reCAPTCHA v2 — use Google test keys for local dev (see https://www.google.com/recaptcha/admin)
+RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+# CORS — comma-separated list of allowed frontend origins
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://frontend:5173

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,5 @@
 VITE_API_URL=http://localhost:8000
 
+# reCAPTCHA v2 public site key (https://www.google.com/recaptcha/admin)
+# Use Google test keys for local dev
+VITE_RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "lucide-react": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-google-recaptcha": "^3.1.0",
     "react-hook-form": "^7.73.1",
     "react-router-dom": "^6.23.1"
   },
@@ -29,6 +30,7 @@
     "@eslint/js": "^9.25.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-google-recaptcha": "^2.1.9",
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -22,14 +22,14 @@ export default function Register() {
   const [loading, setLoading] = useState(false)
 
   if (!SITE_KEY || !API_URL) {
-    return (
-      <p style={{ color: 'red', padding: 24 }}>
-        Configuration error: VITE_RECAPTCHA_SITE_KEY or VITE_API_URL is not set.
-        Check your frontend/.env file.
-      </p>
+  return (
+    <p style={{ color: 'red', padding: 24 }}>
+      {import.meta.env.DEV
+        ? 'Dev config error: VITE_RECAPTCHA_SITE_KEY or VITE_API_URL missing in frontend/.env'
+        : 'Registration is temporarily unavailable. Please try again later.'}
+    </p>
     )
   }
-
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const token = recaptchaRef.current?.getValue()

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -12,11 +12,23 @@ import ReCAPTCHA from 'react-google-recaptcha'
 //   7. recaptchaRef.current?.reset() after submit
 //   Available roles: 'startup' | 'investor' | 'org_admin'
 
+const SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY as string | undefined
+const API_URL = import.meta.env.VITE_API_URL as string | undefined
+
 export default function Register() {
   const recaptchaRef = useRef<ReCAPTCHA>(null)
   const [message, setMessage] = useState('')
   const [isError, setIsError] = useState(false)
   const [loading, setLoading] = useState(false)
+
+  if (!SITE_KEY || !API_URL) {
+    return (
+      <p style={{ color: 'red', padding: 24 }}>
+        Configuration error: VITE_RECAPTCHA_SITE_KEY or VITE_API_URL is not set.
+        Check your frontend/.env file.
+      </p>
+    )
+  }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -29,7 +41,7 @@ export default function Register() {
     const form = e.currentTarget
     setLoading(true)
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/register/`, {
+      const res = await fetch(`${API_URL}/api/auth/register/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -63,7 +75,7 @@ export default function Register() {
           <option value="investor">Investor</option>
           <option value="org_admin">Org Admin</option>
         </select>
-        <ReCAPTCHA ref={recaptchaRef} sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY} />
+        <ReCAPTCHA ref={recaptchaRef} sitekey={SITE_KEY} />
         <button type="submit" disabled={loading} style={{ padding: '10px 0', borderRadius: 4, background: '#2563eb', color: '#fff', border: 'none', cursor: 'pointer' }}>
           {loading ? 'Loading...' : 'Register'}
         </button>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,4 +1,74 @@
-export default function Register() {
-  return <h1>Register</h1>
-}
+import { useRef, useState } from 'react'
+import ReCAPTCHA from 'react-google-recaptcha'
 
+// TODO(#72, #73): Minimal stub for testing reCAPTCHA + backend integration.
+// Replace with full design. Preserve:
+//   1. react-google-recaptcha (already in package.json)
+//   2. import ReCAPTCHA from 'react-google-recaptcha'
+//   3. const recaptchaRef = useRef<ReCAPTCHA>(null)
+//   4. <ReCAPTCHA ref={recaptchaRef} sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY} />
+//   5. const token = recaptchaRef.current?.getValue() on submit
+//   6. Include recaptcha_token: token in POST /api/auth/register/ body
+//   7. recaptchaRef.current?.reset() after submit
+//   Available roles: 'startup' | 'investor' | 'org_admin'
+
+export default function Register() {
+  const recaptchaRef = useRef<ReCAPTCHA>(null)
+  const [message, setMessage] = useState('')
+  const [isError, setIsError] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const token = recaptchaRef.current?.getValue()
+    if (!token) {
+      setIsError(true)
+      setMessage('Please complete the captcha')
+      return
+    }
+    const form = e.currentTarget
+    setLoading(true)
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/register/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: (form.elements.namedItem('email') as HTMLInputElement).value,
+          password: (form.elements.namedItem('password') as HTMLInputElement).value,
+          role: (form.elements.namedItem('role') as HTMLSelectElement).value,
+          recaptcha_token: token,
+        }),
+      })
+      const json = await res.json()
+      setIsError(!res.ok)
+      const errorMsg = json.detail || Object.values(json).flat().join('. ')
+      setMessage(res.ok ? json.detail : errorMsg)
+    } catch {
+      setIsError(true)
+      setMessage('Network error')
+    } finally {
+      setLoading(false)
+      recaptchaRef.current?.reset()
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 400, margin: '60px auto', padding: 24, border: '1px solid #ddd', borderRadius: 8 }}>
+      <h2 style={{ marginBottom: 20 }}>Register</h2>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <input name="email" type="email" placeholder="Email" required style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc' }} />
+        <input name="password" type="password" placeholder="Password" required style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc' }} />
+        <select name="role" style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc' }}>
+          <option value="startup">Startup</option>
+          <option value="investor">Investor</option>
+          <option value="org_admin">Org Admin</option>
+        </select>
+        <ReCAPTCHA ref={recaptchaRef} sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY} />
+        <button type="submit" disabled={loading} style={{ padding: '10px 0', borderRadius: 4, background: '#2563eb', color: '#fff', border: 'none', cursor: 'pointer' }}>
+          {loading ? 'Loading...' : 'Register'}
+        </button>
+        {message && <p style={{ color: isError ? 'red' : 'green' }}>{message}</p>}
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string
+  readonly VITE_RECAPTCHA_SITE_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 declare module "*.module.css" {
   const classes: { [key: string]: string };
   export default classes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "python-decouple==3.8",
   "psycopg2-binary==2.9.11",
   "djangorestframework-simplejwt==5.5.0",
-  "requests==2.32.3", 
+  "requests>=2.32.3,<3" 
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "python-decouple==3.8",
   "psycopg2-binary==2.9.11",
   "djangorestframework-simplejwt==5.5.0",
+  "requests==2.32.3", 
 ]
 
 [project.optional-dependencies]

--- a/scalea/.env.example
+++ b/scalea/.env.example
@@ -4,3 +4,10 @@ ALLOWED_HOSTS=localhost,127.0.0.1,backend
 SECRET_KEY='your_secret_key_here'
 # Password reset token lifetime in seconds (default 5 minutes)
 PASSWORD_RESET_TIMEOUT=300
+
+# reCAPTCHA v2 (https://www.google.com/recaptcha/admin)
+# Use Google test keys for local dev (always pass), replace with real keys for production
+RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+# CORS — allowed frontend origins (comma-separated)
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://frontend:5173

--- a/scalea/scalea/settings.py
+++ b/scalea/scalea/settings.py
@@ -14,6 +14,7 @@ from datetime import timedelta
 from pathlib import Path
 
 from decouple import Csv, config
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -194,6 +195,12 @@ SIMPLE_JWT = {
 FRONTEND_URL = config('FRONTEND_URL', default='http://localhost:5173')
 
 RECAPTCHA_SECRET_KEY = config('RECAPTCHA_SECRET_KEY', default='')
+
+if not DEBUG and not RECAPTCHA_SECRET_KEY:
+    raise ImproperlyConfigured(
+        'RECAPTCHA_SECRET_KEY must be set in production (DEBUG=False). '
+        'Use Google test key for local dev.'
+    )
 
 # Email backend: use console backend in local dev, SMTP in staging/production.
 EMAIL_BACKEND = config(

--- a/scalea/scalea/settings.py
+++ b/scalea/scalea/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from datetime import timedelta
 from pathlib import Path
 
-from decouple import config
+from decouple import Csv, config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -154,11 +154,11 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CORS_ALLOWED_ORIGINS = [
-    'http://localhost:5173',
-    'http://127.0.0.1:5173',
-    'http://frontend:5173',
-]
+CORS_ALLOWED_ORIGINS = config(
+    'CORS_ALLOWED_ORIGINS',
+    default='http://localhost:5173,http://127.0.0.1:5173,http://frontend:5173',
+    cast=Csv(),
+)
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
@@ -176,6 +176,7 @@ REST_FRAMEWORK = {
         'anon': '100/day',
         'user': '1000/day',
         'login': '10/hour',
+        'register': '5/hour',
         'refresh': '10/minute',
         'logout': '10/minute',
         'password_reset': '5/hour',
@@ -191,6 +192,8 @@ SIMPLE_JWT = {
 }
 
 FRONTEND_URL = config('FRONTEND_URL', default='http://localhost:5173')
+
+RECAPTCHA_SECRET_KEY = config('RECAPTCHA_SECRET_KEY', default='')
 
 # Email backend: use console backend in local dev, SMTP in staging/production.
 EMAIL_BACKEND = config(

--- a/scalea/users/security.py
+++ b/scalea/users/security.py
@@ -1,5 +1,6 @@
 from django.core.cache import cache
 
+# --- Login per-email protection ---
 MAX_FAILED_ATTEMPTS = 5
 LOCKOUT_SECONDS = 15 * 60
 
@@ -12,11 +13,11 @@ def _lock_key(email: str) -> str:
     return f'auth:login:lock:{email}'
 
 
-def is_locked(email: str) -> bool:
+def is_login_locked(email: str) -> bool:
     return bool(cache.get(_lock_key(email)))
 
 
-def register_failure(email: str) -> None:
+def record_login_failure(email: str) -> None:
     key = _fail_key(email)
     count = int(cache.get(key, 0)) + 1
     cache.set(key, count, timeout=LOCKOUT_SECONDS)
@@ -24,6 +25,31 @@ def register_failure(email: str) -> None:
         cache.set(_lock_key(email), True, timeout=LOCKOUT_SECONDS)
 
 
-def clear_failures(email: str) -> None:
+def clear_login_failures(email: str) -> None:
     cache.delete(_fail_key(email))
     cache.delete(_lock_key(email))
+
+
+# --- Registration per-email protection ---
+MAX_REGISTER_ATTEMPTS = 5
+REGISTER_LOCKOUT_SECONDS = 60 * 60  # 1 hour
+
+
+def _reg_count_key(email: str) -> str:
+    return f'auth:register:count:{email}'
+
+
+def _reg_lock_key(email: str) -> str:
+    return f'auth:register:lock:{email}'
+
+
+def is_register_locked(email: str) -> bool:
+    return bool(cache.get(_reg_lock_key(email)))
+
+
+def record_register_attempt(email: str) -> None:
+    key = _reg_count_key(email)
+    count = int(cache.get(key, 0)) + 1
+    cache.set(key, count, timeout=REGISTER_LOCKOUT_SECONDS)
+    if count >= MAX_REGISTER_ATTEMPTS:
+        cache.set(_reg_lock_key(email), True, timeout=REGISTER_LOCKOUT_SECONDS)

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -678,7 +678,7 @@ class RegisterSecurityTests(APITestCase):
     def test_per_email_lockout_after_5_attempts(self, mock_post):
         mock_post.return_value.json.return_value = {'success': True}
 
-        for _ in range(5):
+        for _ in range(6):
             cache.delete('throttle_register_127.0.0.1')
             self.client.post(self.url, self.valid_data, format='json')
 

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -1,6 +1,7 @@
 import re
 from unittest.mock import patch
 
+import requests as req_lib
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.cache import cache
@@ -42,6 +43,7 @@ class UserModelTests(TestCase):
 
 class RegistrationAPITests(TestCase):
     def setUp(self):
+        cache.clear()
         self.client = APIClient()
         self.url = reverse('register')
         self.valid_startup_data = {
@@ -626,3 +628,76 @@ class RefreshAndLogoutApiTests(APITestCase):
             format='json',
         )
         self.assertEqual(investor_login_response.status_code, status.HTTP_200_OK)
+
+
+class RegisterSecurityTests(APITestCase):
+    """Tests for reCAPTCHA and per-email throttling on registration."""
+
+    def setUp(self):
+        cache.clear()
+        self.url = reverse('register')
+        self.valid_data = {
+            'email': 'security@example.com',
+            'password': 'StrongPassword123!',
+            'role': 'startup',
+            'recaptcha_token': 'fake-token',
+        }
+
+    @patch('users.views.requests.post')
+    @override_settings(RECAPTCHA_SECRET_KEY='test-secret')
+    def test_captcha_success_allows_registration(self, mock_post):
+        mock_post.return_value.json.return_value = {'success': True}
+        response = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @patch('users.views.requests.post')
+    @override_settings(RECAPTCHA_SECRET_KEY='test-secret')
+    def test_captcha_failure_returns_400(self, mock_post):
+        mock_post.return_value.json.return_value = {'success': False}
+        response = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['detail'], 'Invalid captcha. Please try again.')
+
+    @patch('users.views.requests.post', side_effect=req_lib.RequestException('timeout'))
+    @override_settings(RECAPTCHA_SECRET_KEY='test-secret')
+    def test_captcha_service_down_returns_503(self, _mock_post):
+        with self.assertLogs('users.views', level='WARNING') as cm:
+            response = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertTrue(any('reCAPTCHA' in msg for msg in cm.output))
+
+    @override_settings(RECAPTCHA_SECRET_KEY='', DEBUG=True)
+    def test_no_captcha_key_dev_mode_skips_verification(self):
+        data = self.valid_data.copy()
+        data.pop('recaptcha_token')
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @patch('users.views.requests.post')
+    @override_settings(RECAPTCHA_SECRET_KEY='test-secret')
+    def test_per_email_lockout_after_5_attempts(self, mock_post):
+        mock_post.return_value.json.return_value = {'success': True}
+
+        for _ in range(5):
+            cache.delete('throttle_register_127.0.0.1')
+            self.client.post(self.url, self.valid_data, format='json')
+
+        response = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertIn('Too many registration attempts', response.data['detail'])
+
+    @patch('users.views.requests.post')
+    @override_settings(RECAPTCHA_SECRET_KEY='test-secret')
+    def test_different_email_not_affected_by_lockout(self, mock_post):
+        """Lockout on one email does not affect another email."""
+        mock_post.return_value.json.return_value = {'success': True}
+
+        for _ in range(5):
+            cache.delete('throttle_register_127.0.0.1')
+            self.client.post(self.url, self.valid_data, format='json')
+
+        other_data = self.valid_data.copy()
+        other_data['email'] = 'other@example.com'
+        cache.delete('throttle_register_127.0.0.1')
+        response = self.client.post(self.url, other_data, format='json')
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 from datetime import timedelta
 
+import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
@@ -180,8 +181,29 @@ class PasswordResetConfirmView(APIView):
 class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer
     permission_classes = [AllowAny]
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'register'
 
     def create(self, request, *args, **kwargs):  # noqa: ARG002
+        if settings.RECAPTCHA_SECRET_KEY:
+            token = request.data.get('recaptcha_token')
+            try:
+                resp = requests.post(
+                    'https://www.google.com/recaptcha/api/siteverify',
+                    data={
+                        'secret': settings.RECAPTCHA_SECRET_KEY,
+                        'response': token,
+                    },
+                    timeout=5,
+                )
+                if not resp.json().get('success'):
+                    return Response(
+                        {'detail': 'Invalid captcha. Please try again.'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+            except Exception:
+                logger.warning('reCAPTCHA verification request failed')
+
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -204,12 +204,13 @@ class RegisterView(generics.CreateAPIView):
                     },
                     timeout=5,
                 )
+                resp.raise_for_status()
                 if not resp.json().get('success'):
                     return Response(
                         {'detail': 'Invalid captcha. Please try again.'},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
-            except requests.RequestException:
+            except (requests.RequestException, ValueError):
                 logger.warning('reCAPTCHA verification request failed')
                 return Response(
                     {
@@ -217,12 +218,14 @@ class RegisterView(generics.CreateAPIView):
                     },
                     status=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
+        serializer = self.get_serializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+            user = serializer.save()
+        except Exception:
             if email:
                 record_register_attempt(email)
-
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        user = serializer.save()
+            raise
 
         return Response(
             {

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -39,9 +39,11 @@ from startups.serializers import (
 
 from .models import PasswordResetAudit
 from .security import (
-    clear_failures,
-    is_locked,
-    register_failure,
+    clear_login_failures,
+    is_login_locked,
+    is_register_locked,
+    record_login_failure,
+    record_register_attempt,
 )
 from .serializers import (
     LoginSerializer,
@@ -185,6 +187,12 @@ class RegisterView(generics.CreateAPIView):
     throttle_scope = 'register'
 
     def create(self, request, *args, **kwargs):  # noqa: ARG002
+        email = request.data.get('email', '').strip().lower()
+        if email and is_register_locked(email):
+            return Response(
+                {'detail': 'Too many registration attempts. Please try again later.'},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
         if settings.RECAPTCHA_SECRET_KEY:
             token = request.data.get('recaptcha_token')
             try:
@@ -209,6 +217,8 @@ class RegisterView(generics.CreateAPIView):
                     },
                     status=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
+            if email:
+                record_register_attempt(email)
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -232,7 +242,7 @@ class LoginView(APIView):
         raw_email = request.data.get('email')
         email = raw_email.strip().lower() if isinstance(raw_email, str) else ''
 
-        if email and is_locked(email):
+        if email and is_login_locked(email):
             return Response(
                 {'detail': ['Too many failed attempts. Try again later.']},
                 status=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -242,7 +252,7 @@ class LoginView(APIView):
         if not serializer.is_valid():
             if 'detail' in serializer.errors:
                 if email:
-                    register_failure(email)
+                    record_login_failure(email)
                 return Response(serializer.errors, status=status.HTTP_401_UNAUTHORIZED)
 
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -257,7 +267,7 @@ class LoginView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        clear_failures(email)
+        clear_login_failures(email)
 
         refresh = RefreshToken.for_user(user)
         access = refresh.access_token

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -201,8 +201,14 @@ class RegisterView(generics.CreateAPIView):
                         {'detail': 'Invalid captcha. Please try again.'},
                         status=status.HTTP_400_BAD_REQUEST,
                     )
-            except Exception:
+            except requests.RequestException:
                 logger.warning('reCAPTCHA verification request failed')
+                return Response(
+                    {
+                        'detail': 'Captcha service temporarily unavailable. Please try again.'
+                    },
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Closes #67

Implements bot protection, rate limiting and CORS enforcement for the registration
endpoint. Adds a security runbook documenting deployment secrets and monitoring rules.

## Changes

**scalea/scalea/settings.py**
- `CORS_ALLOWED_ORIGINS` now reads from `.env` via `Csv()` cast instead of hardcoded list
- Added `RECAPTCHA_SECRET_KEY` config (defaults to `''` for local dev)
- Added `register: 5/hour` scope to `DEFAULT_THROTTLE_RATES`
- Added production guard: raises `ImproperlyConfigured` if `RECAPTCHA_SECRET_KEY` is empty and `DEBUG=False`

**scalea/users/security.py**
- Added per-email registration protection: `is_register_locked()`, `record_register_attempt()` (5 attempts/hour, separate cache keys `auth:register:*`)

**scalea/users/views.py**
- `RegisterView`: added `ScopedRateThrottle` with `throttle_scope = 'register'` (per-IP)
- `RegisterView.create()`: added per-email lockout check via `is_register_locked()`
- `RegisterView.create()`: added Google reCAPTCHA v2 verification via `siteverify` API (fail-closed: returns 503 on network errors, not a silent bypass)
- `record_register_attempt()` called after successful captcha (counts only human-verified attempts)

**pyproject.toml**
- Added `requests==2.32.3`

**scalea/users/tests.py**
- Added `cache.clear()` to `RegistrationAPITests.setUp()` to prevent throttle interference
- Added `RegisterSecurityTests` class (6 tests): captcha success/failure/service-down, dev mode skip, per-email lockout, different-email isolation

**frontend/src/vite-env.d.ts**
- Added `/// <reference types="vite/client" />` and `ImportMetaEnv` interface (fixes TypeScript build error)

**frontend/src/pages/Register.tsx**
- Minimal registration stub with reCAPTCHA v2 widget (`react-google-recaptcha`)
- Includes `TODO(#72, #73)` comment for future UI with full integration instructions

**frontend/package.json**
- Added `react-google-recaptcha ^3.1.0` and `@types/react-google-recaptcha ^2.1.9`

**env.example / scalea/.env.example / frontend/.env.example**
- Documented `RECAPTCHA_SECRET_KEY`, `CORS_ALLOWED_ORIGINS`, `VITE_RECAPTCHA_SITE_KEY`
- Google public test keys as defaults for local dev

**docs/security/registration.md** (new)
- reCAPTCHA v2 flow, per-IP and per-email rate limiting, CORS policy
- Required env variables reference
- Monitoring & alerting runbook

## How to review

```bash
cp env.example .env
cp scalea/.env.example scalea/.env
cp frontend/.env.example frontend/.env
docker-compose up --build
````

Open `http://localhost:5173/register`, complete captcha, submit.

__Expected:__

- `201` — registration successful
- `400 {"detail": "Invalid captcha..."}` — captcha failed
- `429` — IP throttle (>5/hour) or email lockout (>5 attempts same email)
- `503` — captcha service down (fail-closed)

## Notes

- `Register.tsx` is a stub, full UI in 
- #72
- #73

