### PR TITLE
[BE -187]: SuperAdmin Moderation & Email Notifications 

### DIFF
--- a/scalea/projects/permissions.py
+++ b/scalea/projects/permissions.py
@@ -27,7 +27,7 @@ class IsProjectOwnerOrOrgAdmin(permissions.BasePermission):
             return True
 
         is_owner = obj.startup.user == user
-        is_admin = user.is_org_admin and obj.startup.user == user
+        is_admin = user.is_org_admin
 
         return is_owner or is_admin
 
@@ -46,12 +46,10 @@ class ProjectVisibilityPermission(permissions.BasePermission):
         if obj.visibility == ProjectVisibility.UNLISTED:
             return (
                 obj.startup.user == request.user
-                or (request.user.is_org_admin and obj.startup.user == request.user)
+                or request.user.is_org_admin
                 or obj.investment_set.filter(
                     investor_profile__user=request.user
                 ).exists()
             )
 
-        return obj.startup.user == request.user or (
-            request.user.is_org_admin and obj.startup.user == request.user
-        )
+        return obj.startup.user == request.user or request.user.is_org_admin

--- a/scalea/scalea/urls.py
+++ b/scalea/scalea/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/health/', health_check),
     path('api/auth/', include('users.urls')),
+    path('api/admin/users/', include('users.admin_urls')),
     path('api/content/landing/', LandingContentAPIView.as_view()),
     path('api/startups/', include('startups.urls')),
     path('api/users/', include('investors.urls')),

--- a/scalea/users/admin_urls.py
+++ b/scalea/users/admin_urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from .views import AdminUserModerationListView, VerifyOrgAdminView
+
+urlpatterns = [
+    path('', AdminUserModerationListView.as_view(), name='admin-user-moderation-list'),
+    path(
+        '<int:pk>/verify-org-admin/',
+        VerifyOrgAdminView.as_view(),
+        name='verify-org-admin',
+    ),
+]

--- a/scalea/users/permissions.py
+++ b/scalea/users/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsSuperAdmin(BasePermission):
+    def has_permission(self, request, _view):
+        return bool(
+            request.user and request.user.is_authenticated and request.user.is_superuser
+        )

--- a/scalea/users/serializers.py
+++ b/scalea/users/serializers.py
@@ -200,3 +200,9 @@ class LogoutSerializer(serializers.Serializer):
 
     def save(self):
         self.validated_data['token_obj'].blacklist()
+
+
+class AdminUserModerationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'email', 'is_org_admin', 'is_verified', 'created_at')

--- a/scalea/users/templates/email/org_admin_pending.html
+++ b/scalea/users/templates/email/org_admin_pending.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body style="margin:0; padding:0; background-color:#f4f4f4; font-family: Arial, sans-serif;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4; padding: 40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; overflow:hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
+
+          <tr>
+            <td style="background-color:#1a1a2e; padding: 30px; text-align:center;">
+              <h1 style="color:#ffffff; margin:0; font-size:24px; letter-spacing:2px;">SCALEA</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 40px 50px;">
+              <h2 style="color:#1a1a2e; margin-top:0;">Welcome to Scalea</h2>
+              <p style="color:#555555; line-height:1.6;">Hi {{ user_name }},</p>
+              <p style="color:#555555; line-height:1.6;">
+                Your Org-Admin registration request has been received and is currently pending SuperAdmin approval.
+              </p>
+              <p style="color:#555555; line-height:1.6;">
+                You will receive another email as soon as your account is verified.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#f9f9f9; padding: 20px 50px; border-top: 1px solid #eeeeee;">
+              <p style="color:#aaaaaa; font-size:13px; margin:0;">
+                Best regards,<br>
+                <strong style="color:#1a1a2e;">Scalea Team</strong>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/scalea/users/templates/email/org_admin_verified.html
+++ b/scalea/users/templates/email/org_admin_verified.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body style="margin:0; padding:0; background-color:#f4f4f4; font-family: Arial, sans-serif;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4; padding: 40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; overflow:hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
+
+          <tr>
+            <td style="background-color:#1a1a2e; padding: 30px; text-align:center;">
+              <h1 style="color:#ffffff; margin:0; font-size:24px; letter-spacing:2px;">SCALEA</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding: 40px 50px;">
+              <h2 style="color:#1a1a2e; margin-top:0;">Verification Successful</h2>
+              <p style="color:#555555; line-height:1.6;">Hi {{ user_name }},</p>
+              <p style="color:#555555; line-height:1.6;">
+                Your Org-Admin account has been verified by a SuperAdmin.
+              </p>
+              <p style="color:#555555; line-height:1.6;">
+                You can now log in as Org-Admin.
+              </p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="background-color:#f9f9f9; padding: 20px 50px; border-top: 1px solid #eeeeee;">
+              <p style="color:#aaaaaa; font-size:13px; margin:0;">
+                Best regards,<br>
+                <strong style="color:#1a1a2e;">Scalea Team</strong>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/scalea/users/tests.py
+++ b/scalea/users/tests.py
@@ -81,6 +81,26 @@ class RegistrationAPITests(TestCase):
             InvestorProfile.objects.filter(user__email='investor@example.com').exists()
         )
 
+    def test_org_admin_registration_sends_pending_approval_email(self):
+        response = self.client.post(
+            self.url,
+            {
+                'email': 'new-org-admin@example.com',
+                'password': 'StrongPassword123!',
+                'role': 'org_admin',
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['new-org-admin@example.com'])
+        self.assertEqual(
+            mail.outbox[0].subject,
+            'Welcome to Scalea — Org-Admin request pending approval',
+        )
+        self.assertEqual(len(mail.outbox[0].alternatives), 1)
+        self.assertEqual(mail.outbox[0].alternatives[0][1], 'text/html')
+
     def test_registration_duplicate_email_returns_201_and_masks_existence(self):
         existing_email = 'startup@example.com'
         User.objects.create_user(
@@ -701,3 +721,90 @@ class RegisterSecurityTests(APITestCase):
         cache.delete('throttle_register_127.0.0.1')
         response = self.client.post(self.url, other_data, format='json')
         self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+class AdminOrgAdminModerationTests(APITestCase):
+    def setUp(self):
+        self.superadmin = User.objects.create_user(
+            email='superadmin@example.com',
+            username='superadmin@example.com',
+            password='StrongPass123!',
+            is_active=True,
+            is_superuser=True,
+            is_staff=True,
+        )
+        self.org_admin_pending = User.objects.create_user(
+            email='pending-org-admin@example.com',
+            username='pending-org-admin@example.com',
+            password='StrongPass123!',
+            is_active=True,
+            is_org_admin=True,
+            is_verified=False,
+        )
+        self.org_admin_verified = User.objects.create_user(
+            email='verified-org-admin@example.com',
+            username='verified-org-admin@example.com',
+            password='StrongPass123!',
+            is_active=True,
+            is_org_admin=True,
+            is_verified=True,
+        )
+        self.investor_user = User.objects.create_user(
+            email='investor-only@example.com',
+            username='investor-only@example.com',
+            password='StrongPass123!',
+            is_active=True,
+            is_investor=True,
+        )
+        self.list_url = reverse('admin-user-moderation-list')
+
+    def test_superadmin_can_list_pending_org_admin_requests(self):
+        self.client.force_authenticate(user=self.superadmin)
+
+        response = self.client.get(
+            self.list_url,
+            {'role': 'org_admin', 'is_verified': 'false'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], self.org_admin_pending.id)
+        self.assertFalse(response.data[0]['is_verified'])
+        self.assertTrue(response.data[0]['is_org_admin'])
+
+    def test_superadmin_can_verify_org_admin(self):
+        self.client.force_authenticate(user=self.superadmin)
+        verify_url = reverse(
+            'verify-org-admin', kwargs={'pk': self.org_admin_pending.id}
+        )
+
+        response = self.client.patch(verify_url, {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.org_admin_pending.refresh_from_db()
+        self.assertTrue(self.org_admin_pending.is_verified)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [self.org_admin_pending.email])
+        self.assertEqual(
+            mail.outbox[0].subject,
+            'Scalea — Org-Admin verification successful',
+        )
+        self.assertEqual(len(mail.outbox[0].alternatives), 1)
+        self.assertEqual(mail.outbox[0].alternatives[0][1], 'text/html')
+
+    def test_non_superadmin_cannot_access_moderation_endpoints(self):
+        self.client.force_authenticate(user=self.investor_user)
+        verify_url = reverse(
+            'verify-org-admin', kwargs={'pk': self.org_admin_pending.id}
+        )
+
+        list_response = self.client.get(
+            self.list_url,
+            {'role': 'org_admin', 'is_verified': 'false'},
+            format='json',
+        )
+        verify_response = self.client.patch(verify_url, {}, format='json')
+
+        self.assertEqual(list_response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(verify_response.status_code, status.HTTP_403_FORBIDDEN)

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -38,6 +38,7 @@ from startups.serializers import (
 )
 
 from .models import PasswordResetAudit
+from .permissions import IsSuperAdmin
 from .security import (
     clear_login_failures,
     is_login_locked,
@@ -46,6 +47,7 @@ from .security import (
     record_register_attempt,
 )
 from .serializers import (
+    AdminUserModerationSerializer,
     LoginSerializer,
     LogoutSerializer,
     PasswordResetConfirmSerializer,
@@ -56,6 +58,71 @@ from .tokens import password_reset_token
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
+
+
+def send_org_admin_pending_email(user):
+    display_name = (
+        user.first_name
+        or user.get_full_name().strip()
+        or user.username
+        or user.email.split('@')[0]
+    )
+    html_body = render_to_string(
+        'email/org_admin_pending.html',
+        {'user_name': display_name},
+    )
+    email_msg = EmailMultiAlternatives(
+        subject='Welcome to Scalea — Org-Admin request pending approval',
+        body=(
+            'Welcome to Scalea!\n\n'
+            'Your Org-Admin registration request has been received and is currently '
+            'pending SuperAdmin approval.\n'
+            'You will receive another email as soon as your account is verified.'
+        ),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[user.email],
+    )
+    email_msg.attach_alternative(html_body, 'text/html')
+
+    try:
+        email_msg.send(fail_silently=False)
+    except Exception:
+        logger.exception(
+            'Failed to send pending-approval email to %s',
+            mask_email_for_log(user.email),
+        )
+
+
+def send_org_admin_verified_email(user):
+    display_name = (
+        user.first_name
+        or user.get_full_name().strip()
+        or user.username
+        or user.email.split('@')[0]
+    )
+    html_body = render_to_string(
+        'email/org_admin_verified.html',
+        {'user_name': display_name},
+    )
+    email_msg = EmailMultiAlternatives(
+        subject='Scalea — Org-Admin verification successful',
+        body=(
+            'Great news!\n\n'
+            'Your Org-Admin account has been verified by a SuperAdmin. '
+            'You can now log in as Org-Admin.'
+        ),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[user.email],
+    )
+    email_msg.attach_alternative(html_body, 'text/html')
+
+    try:
+        email_msg.send(fail_silently=False)
+    except Exception:
+        logger.exception(
+            'Failed to send org-admin verified email to %s',
+            mask_email_for_log(user.email),
+        )
 
 
 def get_client_ip(request):
@@ -227,6 +294,9 @@ class RegisterView(generics.CreateAPIView):
                 record_register_attempt(email)
             raise
 
+        if serializer.validated_data.get('role') == 'org_admin':
+            send_org_admin_pending_email(user)
+
         return Response(
             {
                 'email': user.email,
@@ -309,6 +379,43 @@ class LogoutView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class AdminUserModerationListView(generics.ListAPIView):
+    serializer_class = AdminUserModerationSerializer
+    permission_classes = [IsSuperAdmin]
+
+    def get_queryset(self):
+        queryset = User.objects.all().order_by('-created_at')
+
+        role = self.request.query_params.get('role')
+        is_verified = self.request.query_params.get('is_verified')
+
+        if role == 'org_admin':
+            queryset = queryset.filter(is_org_admin=True)
+
+        if is_verified is not None:
+            normalized_is_verified = is_verified.strip().lower()
+            if normalized_is_verified == 'true':
+                queryset = queryset.filter(is_verified=True)
+            elif normalized_is_verified == 'false':
+                queryset = queryset.filter(is_verified=False)
+
+        return queryset
+
+
+class VerifyOrgAdminView(generics.UpdateAPIView):
+    queryset = User.objects.all()
+    serializer_class = AdminUserModerationSerializer
+    permission_classes = [IsSuperAdmin]
+    http_method_names = ['patch']
+
+    def patch(self, request, *args, **kwargs):  # noqa: ARG002
+        user = self.get_object()
+        user.is_verified = True
+        user.save(update_fields=['is_verified'])
+        send_org_admin_verified_email(user)
+        return Response(self.get_serializer(user).data, status=status.HTTP_200_OK)
 
 
 class UniversalProfileDetailView(generics.RetrieveUpdateAPIView):

--- a/scalea/users/views.py
+++ b/scalea/users/views.py
@@ -410,7 +410,7 @@ class VerifyOrgAdminView(generics.UpdateAPIView):
     permission_classes = [IsSuperAdmin]
     http_method_names = ['patch']
 
-    def patch(self, request, *args, **kwargs):  # noqa: ARG002
+    def patch(self, _request, *_args, **_kwargs):
         user = self.get_object()
         user.is_verified = True
         user.save(update_fields=['is_verified'])


### PR DESCRIPTION
**Closes**: https://github.com/ITA-Dnipro/UA-4544/issues/187

Implement a SuperAdmin moderation workflow for Org-Admin applications so administrative privileges are granted only after manual verification.

**Changes**:
- Added a SuperAdmin-only verification endpoint:
  - `PATCH /api/admin/users/{id}/verify-org-admin/`
  - Sets `is_verified = true` for the target Org-Admin user.
- Added a SuperAdmin-only moderation list endpoint:
  - `GET /api/admin/users/?role=org_admin&is_verified=false`
  - Returns only pending (unverified) Org-Admin requests.
- Added email notifications for Org-Admin lifecycle:
  - On Org-Admin registration: Pending Approval email.
  - On SuperAdmin approval: Verification Successful email.
- Added dedicated HTML templates for Org-Admin emails:
  - `users/templates/email/org_admin_pending.html`
  - `users/templates/email/org_admin_verified.html`

**Acceptance criteria coverage**
- **Security**: Non-admin users receive `403 Forbidden` on both moderation endpoints.
- **Filtering**: GET moderation list returns only `org_admin` users with `is_verified=false` when corresponding query params are provided.
- **State change**: PATCH verification updates user record (`is_verified=true`) in DB.
- **Email delivery**: Both registration and verification notifications are sent with HTML-formatted content (verifiable via console backend or Mailtrap SMTP).
- **Tests**: All relevant tests pass.

**Check**: Automated tests

`docker compose exec backend python manage.py test users`
